### PR TITLE
Use ctx size

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -764,6 +764,10 @@ impl App {
         self.confirm_editing_port = !self.confirm_editing_port;
     }
 
+    pub fn toggle_use_ctx_size(&mut self) {
+        self.config.use_ctx_size = !self.config.use_ctx_size;
+    }
+
     pub fn confirm_port_push(&mut self, c: char) {
         if c.is_ascii_digit() && self.confirm_port_input.len() < 5 {
             self.confirm_port_input.push(c);

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,6 +7,7 @@ use std::path::PathBuf;
 #[serde(default)]
 pub struct BackendPreset {
     pub ctx_size: Option<u32>,
+    pub use_ctx_size: Option<bool>,
     pub host: Option<String>,
     pub port: Option<u16>,
     pub flash_attn: Option<bool>,
@@ -22,6 +23,7 @@ impl Default for BackendPreset {
             ctx_size: None,
             host: None,
             port: None,
+            use_ctx_size: None,
             flash_attn: None,
             batch_size: None,
             gpu_layers: None,
@@ -37,6 +39,7 @@ pub struct Config {
     pub extra_model_dirs: Vec<PathBuf>,
     pub preferred_port: u16,
     pub preferred_host: String,
+    pub use_ctx_size: bool,
     pub default_ctx_size: u32,
     pub flash_attn: bool,
     pub default_backend: Option<String>,
@@ -127,6 +130,7 @@ impl Default for Config {
             extra_model_dirs: Vec::new(),
             preferred_port: 8080,
             preferred_host: "0.0.0.0".into(),
+            use_ctx_size: true,
             default_ctx_size: 8192,
             flash_attn: true,
             default_backend: None,
@@ -167,6 +171,9 @@ impl Config {
             ctx_size: preset
                 .and_then(|p| p.ctx_size)
                 .unwrap_or(self.default_ctx_size),
+            use_ctx_size: preset
+                .and_then(|p| p.use_ctx_size)
+                .unwrap_or(self.use_ctx_size),
             host: preset
                 .and_then(|p| p.host.clone())
                 .unwrap_or_else(|| self.preferred_host.clone()),
@@ -184,6 +191,7 @@ impl Config {
 #[derive(Debug, Clone)]
 pub struct ResolvedPreset {
     pub ctx_size: u32,
+    pub use_ctx_size: bool,
     pub host: String,
     pub port: u16,
     pub flash_attn: bool,

--- a/src/events.rs
+++ b/src/events.rs
@@ -144,6 +144,7 @@ fn handle_confirm(app: &mut App, key: KeyEvent) {
         KeyCode::Left | KeyCode::Char('h') => app.confirm_cycle_backend_left(),
         KeyCode::Right | KeyCode::Char('l') => app.confirm_cycle_backend_right(),
         KeyCode::Tab | KeyCode::Char('p') => app.confirm_toggle_port_edit(),
+        KeyCode::Char(' ') => app.toggle_use_ctx_size(),
         _ => {}
     }
 }

--- a/src/models.rs
+++ b/src/models.rs
@@ -630,7 +630,10 @@ mod tests {
         let names: std::collections::HashSet<String> =
             models.iter().map(|m| m.name.clone()).collect();
         assert!(names.contains("Qwen3-8B-Q8_0"), "got names: {names:?}");
-        assert!(names.contains("qwen2.5-coder-3b-q8_0"), "got names: {names:?}");
+        assert!(
+            names.contains("qwen2.5-coder-3b-q8_0"),
+            "got names: {names:?}"
+        );
         assert_eq!(names.len(), 2, "names should be distinct, got: {names:?}");
 
         fs::remove_dir_all(&tmp).unwrap();

--- a/src/server.rs
+++ b/src/server.rs
@@ -212,12 +212,14 @@ fn launch_llama_server(model: &DiscoveredModel, config: &Config) -> Result<Serve
     let mut cmd = Command::new("llama-server");
     cmd.arg("--model")
         .arg(&model.path)
-        .arg("--ctx-size")
-        .arg(preset.ctx_size.to_string())
         .arg("--host")
         .arg(&preset.host)
         .arg("--port")
         .arg(preset.port.to_string());
+
+    if preset.use_ctx_size {
+        cmd.arg("--ctx-size").arg(preset.ctx_size.to_string());
+    }
 
     if preset.flash_attn {
         cmd.arg("--flash-attn").arg("on");
@@ -299,9 +301,11 @@ fn launch_koboldcpp(model: &DiscoveredModel, config: &Config) -> Result<ServerHa
         .arg("--host")
         .arg(&preset.host)
         .arg("--port")
-        .arg(preset.port.to_string())
-        .arg("--contextsize")
-        .arg(preset.ctx_size.to_string());
+        .arg(preset.port.to_string());
+
+    if preset.use_ctx_size {
+        cmd.arg("--contextsize").arg(preset.ctx_size.to_string());
+    }
 
     if let Some(gpu_layers) = preset.gpu_layers {
         cmd.arg("--gpulayers").arg(gpu_layers.to_string());
@@ -345,9 +349,11 @@ fn launch_localai(model: &DiscoveredModel, config: &Config) -> Result<ServerHand
         .arg("--models-path")
         .arg(models_dir)
         .arg("--address")
-        .arg(format!("{}:{}", preset.host, preset.port))
-        .arg("--context-size")
-        .arg(preset.ctx_size.to_string());
+        .arg(format!("{}:{}", preset.host, preset.port));
+
+    if preset.use_ctx_size {
+        cmd.arg("--context-size").arg(preset.ctx_size.to_string());
+    }
 
     if let Some(threads) = preset.threads {
         cmd.arg("--threads").arg(threads.to_string());
@@ -381,9 +387,11 @@ fn launch_lemonade(model: &DiscoveredModel, config: &Config) -> Result<ServerHan
         .arg("--host")
         .arg(&preset.host)
         .arg("--port")
-        .arg(preset.port.to_string())
-        .arg("--ctx-size")
-        .arg(preset.ctx_size.to_string());
+        .arg(preset.port.to_string());
+
+    if preset.use_ctx_size {
+        cmd.arg("--ctx-size").arg(preset.ctx_size.to_string());
+    }
 
     for arg in &preset.extra_args {
         cmd.arg(arg);

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -607,6 +607,12 @@ fn draw_confirm_popup(frame: &mut Frame, app: &App, tc: &ThemeColors) {
         Style::default().fg(tc.accent)
     };
 
+    let use_ctx_size_style = if preset.use_ctx_size {
+        Style::default().fg(tc.accent)
+    } else {
+        Style::default().fg(tc.muted)
+    };
+
     let mut lines = vec![
         Line::from(""),
         Line::from(vec![
@@ -634,13 +640,22 @@ fn draw_confirm_popup(frame: &mut Frame, app: &App, tc: &ThemeColors) {
             ),
         ]),
         Line::from(vec![Span::styled(
-            format!(
-                "  Context: {} │ Flash: {}",
-                preset.ctx_size,
-                if preset.flash_attn { "on" } else { "off" }
-            ),
+            format!("  Flash: {}", if preset.flash_attn { "on" } else { "off" }),
             Style::default().fg(tc.muted),
         )]),
+        Line::from(vec![
+            Span::styled("  Context: ", Style::default().fg(tc.muted)),
+            Span::styled("[", Style::default().fg(tc.muted)),
+            Span::styled(
+                format!("{}", if preset.use_ctx_size { "V" } else { " " },),
+                use_ctx_size_style,
+            ),
+            Span::styled("]", Style::default().fg(tc.muted)),
+            Span::styled(
+                format!(" {}", preset.ctx_size),
+                Style::default().fg(tc.muted),
+            ),
+        ]),
     ];
 
     let mut extras = Vec::new();
@@ -672,7 +687,11 @@ fn draw_confirm_popup(frame: &mut Frame, app: &App, tc: &ThemeColors) {
         )]));
     } else {
         lines.push(Line::from(vec![Span::styled(
-            "  h/l:backend │ p:port │ Enter:serve │ Esc:cancel",
+            "  h/l:backend │ p:port | space: context",
+            Style::default().fg(tc.warning),
+        )]));
+        lines.push(Line::from(vec![Span::styled(
+            "  Enter:serve │ Esc:cancel",
             Style::default().fg(tc.warning),
         )]));
     }


### PR DESCRIPTION
Prior to this change the llmserver always passed the context size to the llm engine.
When using larger model that have a larger context passing the context size to the
engine can limit the capabilities. This is the case for llama.cpp. This commit
adds a configuration option to "use_ctx_size" (or not) when starting the server.

This pull request contains two commits. The first just adds the option to use *or not* the context size.
The second commit adds the UI. The latter IMHO is not that great. I think it would be best to refactor the dialog
to make this (and more) fields editable (port,use_context_size, context size... )
