### PR TITLE
feat: server exit popup, editable serve config, old flash-attn compat

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -2,7 +2,7 @@ use crate::backends::{
     Backend, DetectedBackend, detect_backends, fetch_fastflowlm_models, fetch_lemonade_models,
     fetch_lmstudio_models, fetch_ollama_models,
 };
-use crate::config::Config;
+use crate::config::{Config, ResolvedPreset};
 use crate::models::{
     DiscoveredModel, ModelFormat, ModelSource, add_fastflowlm_models, add_lemonade_models,
     add_lmstudio_models, add_ollama_models, discover_models,
@@ -20,6 +20,41 @@ pub enum InputMode {
     ConfirmServe,
     StopPopup,
     AddDir,
+    ServerExit,
+}
+
+/// Editable fields in the confirm-serve modal, in display order.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConfirmField {
+    Backend,
+    Port,
+    CtxSize,
+    FlashAttn,
+    GpuLayers,
+    Threads,
+    BatchSize,
+    ExtraArgs,
+}
+
+pub const CONFIRM_FIELDS: [ConfirmField; 8] = [
+    ConfirmField::Backend,
+    ConfirmField::Port,
+    ConfirmField::CtxSize,
+    ConfirmField::FlashAttn,
+    ConfirmField::GpuLayers,
+    ConfirmField::Threads,
+    ConfirmField::BatchSize,
+    ConfirmField::ExtraArgs,
+];
+
+/// Details about a server that exited on its own, shown in a popup modal.
+#[derive(Debug, Clone)]
+pub struct ExitInfo {
+    pub model_name: String,
+    pub backend_label: String,
+    pub port: u16,
+    pub message: String,
+    pub log_lines: Vec<String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -117,10 +152,20 @@ pub struct App {
     pub stop_popup_cursor: usize,
     /// Log lines from servers that have exited (so we can see crash output).
     pub dead_logs: VecDeque<String>,
+    /// Queue of unexpected server exits awaiting acknowledgement via popup.
+    pub exit_popups: VecDeque<ExitInfo>,
+    /// Scroll offset (lines up from the bottom) within the exit popup log view.
+    pub exit_popup_scroll: usize,
 
     pub confirm_backend_idx: usize,
     pub confirm_port_input: String,
-    pub confirm_editing_port: bool,
+    /// Working copy of the launch settings, seeded from the backend's preset.
+    pub confirm_preset: ResolvedPreset,
+    /// Index into CONFIRM_FIELDS of the selected field.
+    pub confirm_field: usize,
+    /// Whether the selected field is being text-edited.
+    pub confirm_editing: bool,
+    pub confirm_edit_buf: String,
 
     // Source tree
     pub tree_nodes: Vec<TreeNode>,
@@ -227,9 +272,14 @@ impl App {
             servers: Vec::new(),
             stop_popup_cursor: 0,
             dead_logs: VecDeque::new(),
+            exit_popups: VecDeque::new(),
+            exit_popup_scroll: 0,
             confirm_backend_idx: selected_backend,
             confirm_port_input: String::new(),
-            confirm_editing_port: false,
+            confirm_preset: config.preset_for("llama-server"),
+            confirm_field: 0,
+            confirm_editing: false,
+            confirm_edit_buf: String::new(),
             tree_nodes,
             tree_cursor: 0,
             tree_source_filter: None,
@@ -701,8 +751,19 @@ impl App {
 
         self.confirm_backend_idx = best;
         self.confirm_port_input = self.next_available_port().to_string();
-        self.confirm_editing_port = false;
+        self.confirm_field = 0;
+        self.confirm_editing = false;
+        self.confirm_edit_buf.clear();
+        self.confirm_reseed_preset();
         self.input_mode = InputMode::ConfirmServe;
+    }
+
+    /// Re-seed the working preset from the currently selected backend's config.
+    fn confirm_reseed_preset(&mut self) {
+        if let Some(b) = self.backends.get(self.confirm_backend_idx) {
+            let key = crate::backends::backend_key(&b.backend);
+            self.confirm_preset = self.config.preset_for(key);
+        }
     }
 
     pub fn confirm_backend(&self) -> Option<&DetectedBackend> {
@@ -747,6 +808,7 @@ impl App {
     pub fn confirm_cycle_backend_right(&mut self) {
         if !self.backends.is_empty() {
             self.confirm_backend_idx = (self.confirm_backend_idx + 1) % self.backends.len();
+            self.confirm_reseed_preset();
         }
     }
 
@@ -757,25 +819,155 @@ impl App {
             } else {
                 self.confirm_backend_idx - 1
             };
+            self.confirm_reseed_preset();
         }
     }
 
-    pub fn confirm_toggle_port_edit(&mut self) {
-        self.confirm_editing_port = !self.confirm_editing_port;
+    pub fn confirm_selected_field(&self) -> ConfirmField {
+        CONFIRM_FIELDS[self.confirm_field.min(CONFIRM_FIELDS.len() - 1)]
     }
 
-    pub fn toggle_use_ctx_size(&mut self) {
-        self.config.use_ctx_size = !self.config.use_ctx_size;
+    pub fn confirm_field_down(&mut self) {
+        self.confirm_field = (self.confirm_field + 1) % CONFIRM_FIELDS.len();
     }
 
-    pub fn confirm_port_push(&mut self, c: char) {
-        if c.is_ascii_digit() && self.confirm_port_input.len() < 5 {
-            self.confirm_port_input.push(c);
+    pub fn confirm_field_up(&mut self) {
+        self.confirm_field = if self.confirm_field == 0 {
+            CONFIRM_FIELDS.len() - 1
+        } else {
+            self.confirm_field - 1
+        };
+    }
+
+    /// h/l or Space on the selected field: cycle backend or flip a toggle.
+    pub fn confirm_field_left(&mut self) {
+        match self.confirm_selected_field() {
+            ConfirmField::Backend => self.confirm_cycle_backend_left(),
+            _ => self.confirm_toggle(),
         }
     }
 
-    pub fn confirm_port_pop(&mut self) {
-        self.confirm_port_input.pop();
+    pub fn confirm_field_right(&mut self) {
+        match self.confirm_selected_field() {
+            ConfirmField::Backend => self.confirm_cycle_backend_right(),
+            _ => self.confirm_toggle(),
+        }
+    }
+
+    pub fn confirm_toggle(&mut self) {
+        match self.confirm_selected_field() {
+            ConfirmField::CtxSize => {
+                self.confirm_preset.use_ctx_size = !self.confirm_preset.use_ctx_size;
+            }
+            ConfirmField::FlashAttn => {
+                self.confirm_preset.flash_attn = !self.confirm_preset.flash_attn;
+            }
+            _ => {}
+        }
+    }
+
+    pub fn confirm_begin_edit(&mut self) {
+        let buf = match self.confirm_selected_field() {
+            // Not text-editable
+            ConfirmField::Backend | ConfirmField::FlashAttn => return,
+            ConfirmField::Port => self.confirm_port_input.clone(),
+            ConfirmField::CtxSize => self.confirm_preset.ctx_size.to_string(),
+            ConfirmField::GpuLayers => self
+                .confirm_preset
+                .gpu_layers
+                .map(|v| v.to_string())
+                .unwrap_or_default(),
+            ConfirmField::Threads => self
+                .confirm_preset
+                .threads
+                .map(|v| v.to_string())
+                .unwrap_or_default(),
+            ConfirmField::BatchSize => self
+                .confirm_preset
+                .batch_size
+                .map(|v| v.to_string())
+                .unwrap_or_default(),
+            ConfirmField::ExtraArgs => self.confirm_preset.extra_args.join(" "),
+        };
+        self.confirm_edit_buf = buf;
+        self.confirm_editing = true;
+    }
+
+    pub fn confirm_edit_push(&mut self, c: char) {
+        let ok = match self.confirm_selected_field() {
+            ConfirmField::Port => c.is_ascii_digit() && self.confirm_edit_buf.len() < 5,
+            ConfirmField::CtxSize | ConfirmField::Threads | ConfirmField::BatchSize => {
+                c.is_ascii_digit() && self.confirm_edit_buf.len() < 9
+            }
+            ConfirmField::GpuLayers => {
+                (c.is_ascii_digit() || (c == '-' && self.confirm_edit_buf.is_empty()))
+                    && self.confirm_edit_buf.len() < 5
+            }
+            ConfirmField::ExtraArgs => !c.is_control(),
+            ConfirmField::Backend | ConfirmField::FlashAttn => false,
+        };
+        if ok {
+            self.confirm_edit_buf.push(c);
+        }
+    }
+
+    pub fn confirm_edit_pop(&mut self) {
+        self.confirm_edit_buf.pop();
+    }
+
+    /// Commit the edit buffer into the working preset. Empty optional fields
+    /// become "auto" (None); unparseable input keeps the previous value.
+    pub fn confirm_commit_edit(&mut self) {
+        let buf = self.confirm_edit_buf.trim().to_string();
+        match self.confirm_selected_field() {
+            ConfirmField::Port => {
+                if buf.parse::<u16>().is_ok() {
+                    self.confirm_port_input = buf;
+                }
+            }
+            ConfirmField::CtxSize => {
+                if let Ok(v) = buf.parse() {
+                    self.confirm_preset.ctx_size = v;
+                }
+            }
+            ConfirmField::GpuLayers => self.confirm_preset.gpu_layers = buf.parse().ok(),
+            ConfirmField::Threads => self.confirm_preset.threads = buf.parse().ok(),
+            ConfirmField::BatchSize => self.confirm_preset.batch_size = buf.parse().ok(),
+            ConfirmField::ExtraArgs => {
+                self.confirm_preset.extra_args =
+                    buf.split_whitespace().map(str::to_string).collect();
+            }
+            ConfirmField::Backend | ConfirmField::FlashAttn => {}
+        }
+        self.confirm_editing = false;
+        self.confirm_edit_buf.clear();
+    }
+
+    pub fn confirm_cancel_edit(&mut self) {
+        self.confirm_editing = false;
+        self.confirm_edit_buf.clear();
+    }
+
+    /// Persist the working preset as this backend's defaults in config.toml.
+    pub fn confirm_save_preset(&mut self) {
+        let Some(backend) = self.backends.get(self.confirm_backend_idx) else {
+            return;
+        };
+        let key = crate::backends::backend_key(&backend.backend).to_string();
+        let p = &self.confirm_preset;
+        let entry = self.config.presets.entry(key.clone()).or_default();
+        entry.ctx_size = Some(p.ctx_size);
+        entry.use_ctx_size = Some(p.use_ctx_size);
+        entry.flash_attn = Some(p.flash_attn);
+        entry.batch_size = p.batch_size;
+        entry.gpu_layers = p.gpu_layers;
+        entry.threads = p.threads;
+        entry.extra_args = p.extra_args.clone();
+        if let Ok(port) = self.confirm_port_input.parse::<u16>() {
+            entry.port = Some(port);
+        }
+        self.config.save();
+        self.status_message = Some(format!("Saved defaults for {key}"));
     }
 
     pub fn do_serve(&mut self) {
@@ -818,7 +1010,10 @@ impl App {
             return;
         }
 
-        match server::launch_on_port(&model, &backend.backend, &self.config, port) {
+        let mut preset = self.confirm_preset.clone();
+        preset.port = port;
+
+        match server::launch_with(&model, &backend.backend, &preset) {
             Ok(handle) => {
                 self.status_message = Some(format!(
                     "Started {} via {} on port {}",
@@ -912,6 +1107,14 @@ impl App {
         }
         for (i, msg) in exited.into_iter().rev() {
             let handle = self.servers.remove(i);
+            // Queue a popup so the user sees why the server exited
+            self.exit_popups.push_back(ExitInfo {
+                model_name: handle.model_name.clone(),
+                backend_label: handle.backend.label().to_string(),
+                port: handle.port,
+                message: msg.clone(),
+                log_lines: handle.log_lines.iter().cloned().collect(),
+            });
             // Preserve logs from the dead server
             self.dead_logs.push_back(format!(
                 "--- {} (:{}) exited: {msg} ---",
@@ -928,7 +1131,43 @@ impl App {
                 "{} (port {}): {msg}",
                 handle.model_name, handle.port
             ));
+            self.show_serve = true; // make crash logs visible after dismissal
         }
+
+        // Surface the popup once no other modal is active
+        if !self.exit_popups.is_empty() && self.input_mode == InputMode::Normal {
+            self.exit_popup_scroll = 0;
+            self.input_mode = InputMode::ServerExit;
+        }
+    }
+
+    // -- Server exit popup --
+
+    pub fn current_exit_popup(&self) -> Option<&ExitInfo> {
+        self.exit_popups.front()
+    }
+
+    pub fn dismiss_exit_popup(&mut self) {
+        self.exit_popups.pop_front();
+        self.exit_popup_scroll = 0;
+        if self.exit_popups.is_empty() {
+            self.input_mode = InputMode::Normal;
+        }
+    }
+
+    pub fn exit_popup_scroll_up(&mut self) {
+        let max = self
+            .exit_popups
+            .front()
+            .map(|e| e.log_lines.len())
+            .unwrap_or(0);
+        if self.exit_popup_scroll < max {
+            self.exit_popup_scroll += 1;
+        }
+    }
+
+    pub fn exit_popup_scroll_down(&mut self) {
+        self.exit_popup_scroll = self.exit_popup_scroll.saturating_sub(1);
     }
 
     /// Get all log lines to display — combines live server logs and dead logs.

--- a/src/events.rs
+++ b/src/events.rs
@@ -19,6 +19,7 @@ pub fn handle_events(app: &mut App) -> std::io::Result<bool> {
             InputMode::ConfirmServe => handle_confirm(app, key),
             InputMode::StopPopup => handle_stop_popup(app, key),
             InputMode::AddDir => handle_add_dir(app, key),
+            InputMode::ServerExit => handle_server_exit_popup(app, key),
         }
         return Ok(true);
     }
@@ -125,14 +126,12 @@ fn handle_backend_popup(app: &mut App, key: KeyEvent) {
 }
 
 fn handle_confirm(app: &mut App, key: KeyEvent) {
-    if app.confirm_editing_port {
+    if app.confirm_editing {
         match key.code {
-            KeyCode::Char(c) if c.is_ascii_digit() => app.confirm_port_push(c),
-            KeyCode::Backspace => app.confirm_port_pop(),
-            KeyCode::Tab | KeyCode::Enter => app.confirm_toggle_port_edit(),
-            KeyCode::Esc => {
-                app.confirm_editing_port = false;
-            }
+            KeyCode::Enter | KeyCode::Tab => app.confirm_commit_edit(),
+            KeyCode::Esc => app.confirm_cancel_edit(),
+            KeyCode::Backspace => app.confirm_edit_pop(),
+            KeyCode::Char(c) => app.confirm_edit_push(c),
             _ => {}
         }
         return;
@@ -141,10 +140,13 @@ fn handle_confirm(app: &mut App, key: KeyEvent) {
     match key.code {
         KeyCode::Enter | KeyCode::Char('y') => app.do_serve(),
         KeyCode::Esc | KeyCode::Char('n') | KeyCode::Char('q') => app.cancel_popup(),
-        KeyCode::Left | KeyCode::Char('h') => app.confirm_cycle_backend_left(),
-        KeyCode::Right | KeyCode::Char('l') => app.confirm_cycle_backend_right(),
-        KeyCode::Tab | KeyCode::Char('p') => app.confirm_toggle_port_edit(),
-        KeyCode::Char(' ') => app.toggle_use_ctx_size(),
+        KeyCode::Down | KeyCode::Char('j') => app.confirm_field_down(),
+        KeyCode::Up | KeyCode::Char('k') => app.confirm_field_up(),
+        KeyCode::Left | KeyCode::Char('h') => app.confirm_field_left(),
+        KeyCode::Right | KeyCode::Char('l') => app.confirm_field_right(),
+        KeyCode::Char(' ') => app.confirm_toggle(),
+        KeyCode::Tab | KeyCode::Char('e') | KeyCode::Char('p') => app.confirm_begin_edit(),
+        KeyCode::Char('s') => app.confirm_save_preset(),
         _ => {}
     }
 }
@@ -155,6 +157,15 @@ fn handle_stop_popup(app: &mut App, key: KeyEvent) {
         KeyCode::Down | KeyCode::Char('j') => app.stop_popup_down(),
         KeyCode::Up | KeyCode::Char('k') => app.stop_popup_up(),
         KeyCode::Enter => app.confirm_stop(),
+        _ => {}
+    }
+}
+
+fn handle_server_exit_popup(app: &mut App, key: KeyEvent) {
+    match key.code {
+        KeyCode::Esc | KeyCode::Enter | KeyCode::Char('q') => app.dismiss_exit_popup(),
+        KeyCode::Down | KeyCode::Char('j') => app.exit_popup_scroll_down(),
+        KeyCode::Up | KeyCode::Char('k') => app.exit_popup_scroll_up(),
         _ => {}
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,5 +1,5 @@
 use crate::backends::Backend;
-use crate::config::Config;
+use crate::config::{Config, ResolvedPreset};
 use crate::models::DiscoveredModel;
 use std::collections::VecDeque;
 use std::io::Read;
@@ -163,6 +163,16 @@ pub fn launch(
     backend: &Backend,
     config: &Config,
 ) -> Result<ServerHandle, String> {
+    let key = crate::backends::backend_key(backend);
+    launch_with(model, backend, &config.preset_for(key))
+}
+
+/// Launch with an explicit resolved preset (e.g. edited in the confirm modal).
+pub fn launch_with(
+    model: &DiscoveredModel,
+    backend: &Backend,
+    preset: &ResolvedPreset,
+) -> Result<ServerHandle, String> {
     // Check compatibility: can this backend serve this local model file?
     if !backend.can_serve_local(&model.format) {
         let reason = backend
@@ -177,11 +187,11 @@ pub fn launch(
     }
 
     match backend {
-        Backend::LlamaServer => launch_llama_server(model, config),
-        Backend::MlxLm => launch_mlx(model, config),
-        Backend::KoboldCpp => launch_koboldcpp(model, config),
-        Backend::LocalAi => launch_localai(model, config),
-        Backend::Lemonade => launch_lemonade(model, config),
+        Backend::LlamaServer => launch_llama_server(model, preset),
+        Backend::MlxLm => launch_mlx(model, preset),
+        Backend::KoboldCpp => launch_koboldcpp(model, preset),
+        Backend::LocalAi => launch_localai(model, preset),
+        Backend::Lemonade => launch_lemonade(model, preset),
         // These are blocked by the can_serve_local check above,
         // but match exhaustively for safety.
         Backend::Ollama | Backend::LmStudio | Backend::Vllm | Backend::FastFlowLm => Err(format!(
@@ -191,24 +201,27 @@ pub fn launch(
     }
 }
 
-pub fn launch_on_port(
-    model: &DiscoveredModel,
-    backend: &Backend,
-    config: &Config,
-    port: u16,
-) -> Result<ServerHandle, String> {
-    let mut config = config.clone();
-    let key = crate::backends::backend_key(backend);
-    if let Some(preset) = config.presets.get_mut(key) {
-        preset.port = Some(port);
-    }
-    config.preferred_port = port;
-    launch(model, backend, &config)
+/// Newer llama.cpp (≥ b6325) takes `--flash-attn <on|off|auto>`; older builds
+/// (e.g. Fedora's b6153) take it as a bare boolean flag and exit with
+/// "invalid argument: on" otherwise. Probe once: with the new syntax
+/// `--version` parses and exits 0, with the old syntax arg parsing fails first.
+fn llama_flash_attn_takes_value() -> bool {
+    static TAKES_VALUE: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *TAKES_VALUE.get_or_init(|| {
+        Command::new("llama-server")
+            .args(["--flash-attn", "on", "--version"])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(true)
+    })
 }
 
-fn launch_llama_server(model: &DiscoveredModel, config: &Config) -> Result<ServerHandle, String> {
-    let preset = config.preset_for("llama-server");
-
+fn launch_llama_server(
+    model: &DiscoveredModel,
+    preset: &ResolvedPreset,
+) -> Result<ServerHandle, String> {
     let mut cmd = Command::new("llama-server");
     cmd.arg("--model")
         .arg(&model.path)
@@ -222,7 +235,11 @@ fn launch_llama_server(model: &DiscoveredModel, config: &Config) -> Result<Serve
     }
 
     if preset.flash_attn {
-        cmd.arg("--flash-attn").arg("on");
+        if llama_flash_attn_takes_value() {
+            cmd.arg("--flash-attn").arg("on");
+        } else {
+            cmd.arg("--flash-attn");
+        }
     }
 
     if let Some(batch_size) = preset.batch_size {
@@ -257,14 +274,12 @@ fn launch_llama_server(model: &DiscoveredModel, config: &Config) -> Result<Serve
         Backend::LlamaServer,
         model,
         preset.port,
-        preset.host,
+        preset.host.clone(),
         child,
     ))
 }
 
-fn launch_mlx(model: &DiscoveredModel, config: &Config) -> Result<ServerHandle, String> {
-    let preset = config.preset_for("mlx");
-
+fn launch_mlx(model: &DiscoveredModel, preset: &ResolvedPreset) -> Result<ServerHandle, String> {
     let mut cmd = Command::new("python3");
     cmd.arg("-m")
         .arg("mlx_lm.server")
@@ -287,14 +302,15 @@ fn launch_mlx(model: &DiscoveredModel, config: &Config) -> Result<ServerHandle, 
         Backend::MlxLm,
         model,
         preset.port,
-        preset.host,
+        preset.host.clone(),
         child,
     ))
 }
 
-fn launch_koboldcpp(model: &DiscoveredModel, config: &Config) -> Result<ServerHandle, String> {
-    let preset = config.preset_for("koboldcpp");
-
+fn launch_koboldcpp(
+    model: &DiscoveredModel,
+    preset: &ResolvedPreset,
+) -> Result<ServerHandle, String> {
     let mut cmd = Command::new("koboldcpp");
     cmd.arg("--model")
         .arg(&model.path)
@@ -329,14 +345,15 @@ fn launch_koboldcpp(model: &DiscoveredModel, config: &Config) -> Result<ServerHa
         Backend::KoboldCpp,
         model,
         preset.port,
-        preset.host,
+        preset.host.clone(),
         child,
     ))
 }
 
-fn launch_localai(model: &DiscoveredModel, config: &Config) -> Result<ServerHandle, String> {
-    let preset = config.preset_for("localai");
-
+fn launch_localai(
+    model: &DiscoveredModel,
+    preset: &ResolvedPreset,
+) -> Result<ServerHandle, String> {
     // LocalAI serves models from a directory. We point --models-path at the
     // parent directory of the GGUF file so it discovers it automatically.
     let models_dir = model
@@ -373,14 +390,15 @@ fn launch_localai(model: &DiscoveredModel, config: &Config) -> Result<ServerHand
         Backend::LocalAi,
         model,
         preset.port,
-        preset.host,
+        preset.host.clone(),
         child,
     ))
 }
 
-fn launch_lemonade(model: &DiscoveredModel, config: &Config) -> Result<ServerHandle, String> {
-    let preset = config.preset_for("lemonade");
-
+fn launch_lemonade(
+    model: &DiscoveredModel,
+    preset: &ResolvedPreset,
+) -> Result<ServerHandle, String> {
     let mut cmd = Command::new("lemonade");
     cmd.arg("load")
         .arg(model.path.to_string_lossy().as_ref())
@@ -407,7 +425,7 @@ fn launch_lemonade(model: &DiscoveredModel, config: &Config) -> Result<ServerHan
         Backend::Lemonade,
         model,
         preset.port,
-        preset.host,
+        preset.host.clone(),
         child,
     ))
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -4,7 +4,7 @@ use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, BorderType, Borders, Cell, Clear, Paragraph, Row, Table};
 
-use crate::app::{App, Focus, InputMode};
+use crate::app::{App, CONFIRM_FIELDS, ConfirmField, Focus, InputMode};
 use crate::theme::ThemeColors;
 
 pub fn draw(frame: &mut Frame, app: &mut App) {
@@ -52,6 +52,7 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
         InputMode::ConfirmServe => draw_confirm_popup(frame, app, &tc),
         InputMode::StopPopup => draw_stop_popup(frame, app, &tc),
         InputMode::AddDir => draw_add_dir_popup(frame, app, &tc),
+        InputMode::ServerExit => draw_server_exit_popup(frame, app, &tc),
         _ => {}
     }
 }
@@ -473,11 +474,16 @@ fn draw_status_bar(frame: &mut Frame, app: &App, area: Rect, tc: &ThemeColors) {
         InputMode::ConfirmServe => "CONFIRM",
         InputMode::StopPopup => "STOP",
         InputMode::AddDir => "ADD DIR",
+        InputMode::ServerExit => "EXITED",
     };
 
     let help = match app.input_mode {
         InputMode::Search => "type to filter │ Enter:confirm │ Esc:clear",
         InputMode::StopPopup => "j/k:select │ Enter:stop │ Esc:cancel",
+        InputMode::ServerExit => "j/k:scroll │ Enter/Esc:dismiss",
+        InputMode::ConfirmServe => {
+            "j/k:field │ h/l/Space:change │ e:edit │ s:save default │ Enter:serve │ Esc:cancel"
+        }
         InputMode::AddDir => "type path │ Tab:complete │ Enter:add │ Esc:cancel",
         InputMode::Normal if app.focus == Focus::Tree => {
             "j/k:nav │ Enter:filter │ Space:expand │ a:add │ x:rm │ S+←→:resize │ Tab:next │ q:quit"
@@ -557,137 +563,142 @@ fn draw_backend_popup(frame: &mut Frame, app: &App, tc: &ThemeColors) {
 }
 
 fn draw_confirm_popup(frame: &mut Frame, app: &App, tc: &ThemeColors) {
-    let area = centered_rect(58, 14, frame.area());
+    let area = centered_rect(62, 17, frame.area());
     frame.render_widget(Clear, area);
 
     let block = Block::default()
-        .title(" Confirm Serve ")
+        .title(" Serve Model ")
         .title_style(Style::default().fg(tc.title).add_modifier(Modifier::BOLD))
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)
         .border_style(Style::default().fg(tc.accent))
         .style(Style::default().bg(tc.bg));
 
+    let inner_width = block.inner(area).width as usize;
     let model_name = app.selected_model().map(|m| m.name.as_str()).unwrap_or("?");
 
     let backend = app.confirm_backend();
     let backend_label = backend.map(|b| b.backend.label()).unwrap_or("?");
     let backend_available = backend.is_some_and(|b| b.available);
-    let backend_key_str = backend
-        .map(|b| crate::backends::backend_key(&b.backend))
-        .unwrap_or("unknown");
 
-    let preset = app.config.preset_for(backend_key_str);
-    let already_serving = app.confirm_already_serving();
-
-    let compatible = app.confirm_compatible();
-    let incompatible_reason = app.confirm_incompatible_reason();
-
-    let backend_status = if !compatible {
-        let reason = incompatible_reason.unwrap_or("incompatible");
+    let backend_status = if !app.confirm_compatible() {
+        let reason = app.confirm_incompatible_reason().unwrap_or("incompatible");
         Span::styled(format!(" [{reason}]"), Style::default().fg(tc.error))
     } else if !backend_available {
         Span::styled(" [not found]", Style::default().fg(tc.error))
-    } else if already_serving {
+    } else if app.confirm_already_serving() {
         Span::styled(" [already serving]", Style::default().fg(tc.warning))
     } else {
         Span::styled(" [ready]", Style::default().fg(tc.good))
     };
 
-    let port_display = if app.confirm_editing_port {
-        format!("{}_", app.confirm_port_input)
-    } else {
-        app.confirm_port_input.clone()
-    };
-    let port_style = if app.confirm_editing_port {
-        Style::default()
-            .fg(tc.fg)
-            .add_modifier(Modifier::UNDERLINED)
-    } else {
-        Style::default().fg(tc.accent)
-    };
-
-    let use_ctx_size_style = if preset.use_ctx_size {
-        Style::default().fg(tc.accent)
-    } else {
-        Style::default().fg(tc.muted)
-    };
+    let preset = &app.confirm_preset;
+    let selected = app.confirm_selected_field();
 
     let mut lines = vec![
         Line::from(""),
         Line::from(vec![
-            Span::styled("  Model:   ", Style::default().fg(tc.muted)),
+            Span::styled("    Model:      ", Style::default().fg(tc.muted)),
             Span::styled(model_name, Style::default().fg(tc.fg)),
         ]),
-        Line::from(vec![
-            Span::styled("  Backend: ", Style::default().fg(tc.muted)),
-            Span::styled(
-                format!("< {backend_label} >"),
-                Style::default().fg(tc.accent).add_modifier(Modifier::BOLD),
-            ),
-            backend_status,
-        ]),
-        Line::from(vec![
-            Span::styled("  Port:    ", Style::default().fg(tc.muted)),
-            Span::styled(&port_display, port_style),
-            Span::styled(
-                if app.confirm_editing_port {
-                    "  (type digits, Tab to exit)"
-                } else {
-                    "  (p/Tab to edit)"
-                },
-                Style::default().fg(tc.muted),
-            ),
-        ]),
-        Line::from(vec![Span::styled(
-            format!("  Flash: {}", if preset.flash_attn { "on" } else { "off" }),
-            Style::default().fg(tc.muted),
-        )]),
-        Line::from(vec![
-            Span::styled("  Context: ", Style::default().fg(tc.muted)),
-            Span::styled("[", Style::default().fg(tc.muted)),
-            Span::styled(
-                format!("{}", if preset.use_ctx_size { "V" } else { " " },),
-                use_ctx_size_style,
-            ),
-            Span::styled("]", Style::default().fg(tc.muted)),
-            Span::styled(
-                format!(" {}", preset.ctx_size),
-                Style::default().fg(tc.muted),
-            ),
-        ]),
+        Line::from(""),
     ];
 
-    let mut extras = Vec::new();
-    if let Some(bs) = preset.batch_size {
-        extras.push(format!("batch:{bs}"));
-    }
-    if let Some(gl) = preset.gpu_layers {
-        extras.push(format!("gpu-layers:{gl}"));
-    }
-    if let Some(t) = preset.threads {
-        extras.push(format!("threads:{t}"));
-    }
-    if !preset.extra_args.is_empty() {
-        extras.push(preset.extra_args.join(" "));
-    }
-    if !extras.is_empty() {
-        lines.push(Line::from(vec![Span::styled(
-            format!("  Args:    {}", extras.join(" │ ")),
-            Style::default().fg(tc.muted),
-        )]));
+    let auto = |v: Option<String>| v.unwrap_or_else(|| "auto".into());
+
+    for field in CONFIRM_FIELDS {
+        let is_sel = field == selected;
+        let editing = is_sel && app.confirm_editing;
+
+        let (label, mut value, hint) = match field {
+            ConfirmField::Backend => (
+                "Backend",
+                format!("< {backend_label} >"),
+                String::new(), // status span appended below
+            ),
+            ConfirmField::Port => ("Port", app.confirm_port_input.clone(), String::new()),
+            ConfirmField::CtxSize => (
+                "Context",
+                format!(
+                    "[{}] {}",
+                    if preset.use_ctx_size { "x" } else { " " },
+                    preset.ctx_size
+                ),
+                "(Space toggles)".into(),
+            ),
+            ConfirmField::FlashAttn => (
+                "Flash attn",
+                if preset.flash_attn { "on" } else { "off" }.into(),
+                String::new(),
+            ),
+            ConfirmField::GpuLayers => (
+                "GPU layers",
+                auto(preset.gpu_layers.map(|v| v.to_string())),
+                String::new(),
+            ),
+            ConfirmField::Threads => (
+                "Threads",
+                auto(preset.threads.map(|v| v.to_string())),
+                String::new(),
+            ),
+            ConfirmField::BatchSize => (
+                "Batch",
+                auto(preset.batch_size.map(|v| v.to_string())),
+                String::new(),
+            ),
+            ConfirmField::ExtraArgs => (
+                "Extra args",
+                if preset.extra_args.is_empty() {
+                    "(none)".into()
+                } else {
+                    preset.extra_args.join(" ")
+                },
+                String::new(),
+            ),
+        };
+
+        if editing {
+            value = format!("{}_", app.confirm_edit_buf);
+        }
+        let max_val = inner_width.saturating_sub(18 + hint.len());
+        let value: String = value.chars().take(max_val).collect();
+
+        let marker = if is_sel { "  > " } else { "    " };
+        let value_style = if editing {
+            Style::default()
+                .fg(tc.fg)
+                .add_modifier(Modifier::UNDERLINED)
+        } else if is_sel {
+            Style::default().fg(tc.accent).add_modifier(Modifier::BOLD)
+        } else {
+            Style::default().fg(tc.fg)
+        };
+
+        let mut spans = vec![
+            Span::styled(marker, Style::default().fg(tc.accent)),
+            Span::styled(format!("{label:<12}"), Style::default().fg(tc.muted)),
+            Span::styled(value, value_style),
+        ];
+        if field == ConfirmField::Backend {
+            spans.push(backend_status.clone());
+        } else if is_sel && !hint.is_empty() {
+            spans.push(Span::styled(
+                format!("  {hint}"),
+                Style::default().fg(tc.muted),
+            ));
+        }
+        lines.push(Line::from(spans));
     }
 
     lines.push(Line::from(""));
-
-    if app.confirm_editing_port {
+    if app.confirm_editing {
         lines.push(Line::from(vec![Span::styled(
-            "  Tab:done │ Esc:cancel edit",
+            "  Enter:done │ Esc:cancel edit  (empty = auto)",
             Style::default().fg(tc.warning),
         )]));
     } else {
         lines.push(Line::from(vec![Span::styled(
-            "  h/l:backend │ p:port | space: context",
+            "  j/k:field │ h/l/Space:change │ e:edit │ s:save default",
             Style::default().fg(tc.warning),
         )]));
         lines.push(Line::from(vec![Span::styled(
@@ -819,6 +830,93 @@ fn draw_add_dir_popup(frame: &mut Frame, app: &App, tc: &ThemeColors) {
         "  Tab:complete │ Enter:add │ Esc:cancel",
         Style::default().fg(tc.warning),
     )]));
+
+    frame.render_widget(Paragraph::new(lines).block(block), area);
+}
+
+fn draw_server_exit_popup(frame: &mut Frame, app: &mut App, tc: &ThemeColors) {
+    let Some(info) = app.current_exit_popup() else {
+        return;
+    };
+
+    let frame_area = frame.area();
+    let width = frame_area.width.saturating_sub(8).clamp(40, 80);
+    // 4 header lines + 2 borders, plus the log tail
+    let wanted = info.log_lines.len().max(1) as u16 + 6;
+    let height = wanted.min(frame_area.height.saturating_sub(4)).max(8);
+    let area = centered_rect(width, height, frame_area);
+    frame.render_widget(Clear, area);
+
+    let title = if app.exit_popups.len() > 1 {
+        format!(" Server Exited (1 of {}) ", app.exit_popups.len())
+    } else {
+        " Server Exited ".to_string()
+    };
+
+    let block = Block::default()
+        .title(title)
+        .title_style(Style::default().fg(tc.error).add_modifier(Modifier::BOLD))
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .border_style(Style::default().fg(tc.error))
+        .title_bottom(
+            Line::from(" j/k:scroll │ Enter/Esc:dismiss ")
+                .right_aligned()
+                .style(Style::default().fg(tc.muted)),
+        )
+        .style(Style::default().bg(tc.bg));
+
+    let inner = block.inner(area);
+    let inner_width = inner.width as usize;
+
+    let mut lines = vec![
+        Line::from(vec![
+            Span::styled("  Model:   ", Style::default().fg(tc.muted)),
+            Span::styled(
+                info.model_name.clone(),
+                Style::default().fg(tc.fg).add_modifier(Modifier::BOLD),
+            ),
+        ]),
+        Line::from(vec![
+            Span::styled("  Backend: ", Style::default().fg(tc.muted)),
+            Span::styled(
+                format!("{} (port {})", info.backend_label, info.port),
+                Style::default().fg(tc.accent),
+            ),
+        ]),
+        Line::from(vec![
+            Span::styled("  Status:  ", Style::default().fg(tc.muted)),
+            Span::styled(info.message.clone(), Style::default().fg(tc.error)),
+        ]),
+        Line::from(vec![Span::styled(
+            "  ── last output ──",
+            Style::default().fg(tc.muted),
+        )]),
+    ];
+
+    // Log tail fills the remaining height; scroll offset counts up from the bottom
+    let log_visible = (inner.height as usize).saturating_sub(lines.len());
+    let max_scroll = info.log_lines.len().saturating_sub(log_visible);
+    let scroll = app.exit_popup_scroll.min(max_scroll);
+    let skip = info.log_lines.len().saturating_sub(log_visible + scroll);
+
+    if info.log_lines.is_empty() {
+        lines.push(Line::from(vec![Span::styled(
+            "  (no output captured)",
+            Style::default().fg(tc.muted),
+        )]));
+    } else {
+        for text in info.log_lines.iter().skip(skip).take(log_visible) {
+            let style = log_line_style(text, tc);
+            let truncated: String = text.chars().take(inner_width.saturating_sub(2)).collect();
+            lines.push(Line::from(vec![Span::styled(
+                format!("  {truncated}"),
+                style,
+            )]));
+        }
+    }
+
+    app.exit_popup_scroll = scroll;
 
     frame.render_widget(Paragraph::new(lines).block(block), area);
 }


### PR DESCRIPTION
## What

Three related improvements to server lifecycle visibility and launch configuration:

### Server exit popup
When a served model's process exits on its own, a modal now shows the exit status and a scrollable tail of its output (`j`/`k` to scroll, `Enter`/`Esc` to dismiss). Previously the only signals were a one-line status message and the logs panel — easy to miss, and the actual error often scrolled away. Multiple exits queue with a "(1 of N)" counter, and the logs panel auto-opens so the output is still available after dismissal. User-initiated stops don't trigger it.

### Editable serve configuration in the confirm modal
The "Serve Model" modal is now a form: backend, port, context size (+ on/off toggle), flash attention, GPU layers, threads, batch size, and extra args are all editable per-launch — `j`/`k` to move, `Space`/`h`/`l` to toggle or cycle, `e` to edit, empty optional fields mean "auto". Edits apply to that launch only; `s` saves the current values as the backend's preset defaults in `config.toml`. Under the hood, launchers now take a `ResolvedPreset` directly (`server::launch_with`), replacing `launch_on_port`.

### Compatibility with older llama.cpp builds
llama.cpp builds older than ~b6325 (e.g. Fedora 44's packaged b6153) take `--flash-attn` as a bare boolean flag and exit immediately with `error: invalid argument: on` when passed the newer `--flash-attn on` form. Launch now probes once (`llama-server --flash-attn on --version`, cached in a `OnceLock`) and passes whichever syntax the installed binary accepts. Found while debugging an instant server exit that presented as a ROCm error.

## Testing

- `cargo test` (48 tests) and `cargo clippy` clean (no new warnings), `cargo fmt` applied
- Exercised end-to-end in tmux: crash popup verified with a fake failing llama-server; the config form verified against real llama-server b6153 — toggling context/flash off, GPU layers 0, and adding `--mlock` produced exactly `--model … --host 0.0.0.0 --port 8080 --batch-size 2048 -ngl 0 --mlock`, server healthy on `/health`, and the saved preset round-tripped through `config.toml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)