### PR TITLE
feat: faster startup, crash restart, readiness states, and robustness improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -865,7 +865,7 @@ checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "llmserve"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "crossterm",
  "dirs",

--- a/src/app.rs
+++ b/src/app.rs
@@ -27,6 +27,7 @@ pub enum InputMode {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ConfirmField {
     Backend,
+    Host,
     Port,
     CtxSize,
     FlashAttn,
@@ -36,8 +37,9 @@ pub enum ConfirmField {
     ExtraArgs,
 }
 
-pub const CONFIRM_FIELDS: [ConfirmField; 8] = [
+pub const CONFIRM_FIELDS: [ConfirmField; 9] = [
     ConfirmField::Backend,
+    ConfirmField::Host,
     ConfirmField::Port,
     ConfirmField::CtxSize,
     ConfirmField::FlashAttn,
@@ -48,9 +50,13 @@ pub const CONFIRM_FIELDS: [ConfirmField; 8] = [
 ];
 
 /// Details about a server that exited on its own, shown in a popup modal.
+/// Carries the original model/backend/preset so the server can be relaunched
+/// with identical settings straight from the popup.
 #[derive(Debug, Clone)]
 pub struct ExitInfo {
-    pub model_name: String,
+    pub model: DiscoveredModel,
+    pub backend: Backend,
+    pub preset: crate::config::ResolvedPreset,
     pub backend_label: String,
     pub port: u16,
     pub message: String,
@@ -163,6 +169,9 @@ pub struct App {
     pub confirm_preset: ResolvedPreset,
     /// Index into CONFIRM_FIELDS of the selected field.
     pub confirm_field: usize,
+    /// Trained context length of the selected model (from its GGUF header),
+    /// used to warn when the configured ctx-size exceeds it.
+    pub confirm_model_ctx: Option<u64>,
     /// Whether the selected field is being text-edited.
     pub confirm_editing: bool,
     pub confirm_edit_buf: String,
@@ -178,6 +187,9 @@ pub struct App {
     pub serve_width: u16,
     /// Whether log output wraps long lines.
     pub log_wrap: bool,
+    /// Scroll offset in the log panel, in lines up from the bottom
+    /// (0 = pinned to the latest output).
+    pub log_scroll: usize,
     /// Whether the source tree panel is visible.
     pub show_tree: bool,
     /// Whether the serve/logs panel is visible (user can toggle even when empty).
@@ -203,42 +215,7 @@ impl App {
         let backends = detect_backends();
 
         let mut models = discover_models(&config.extra_model_dirs);
-
-        if let Some(ollama) = backends.iter().find(|b| b.backend == Backend::Ollama) {
-            if ollama.available {
-                if let Some(ref url) = ollama.api_url {
-                    let ollama_models = fetch_ollama_models(url);
-                    add_ollama_models(&mut models, ollama_models);
-                }
-            }
-        }
-
-        if let Some(lmstudio) = backends.iter().find(|b| b.backend == Backend::LmStudio) {
-            if lmstudio.available {
-                if let Some(ref url) = lmstudio.api_url {
-                    let lmstudio_models = fetch_lmstudio_models(url);
-                    add_lmstudio_models(&mut models, lmstudio_models);
-                }
-            }
-        }
-
-        if let Some(lemonade) = backends.iter().find(|b| b.backend == Backend::Lemonade) {
-            if lemonade.available {
-                if let Some(ref url) = lemonade.api_url {
-                    let lemonade_models = fetch_lemonade_models(url);
-                    add_lemonade_models(&mut models, lemonade_models);
-                }
-            }
-        }
-
-        if let Some(flm) = backends.iter().find(|b| b.backend == Backend::FastFlowLm) {
-            if flm.available {
-                if let Some(ref url) = flm.api_url {
-                    let flm_models = fetch_fastflowlm_models(url);
-                    add_fastflowlm_models(&mut models, flm_models);
-                }
-            }
-        }
+        fetch_api_models(&backends, &mut models);
 
         let selected_backend = if let Some(ref pref) = config.default_backend {
             backends
@@ -278,6 +255,7 @@ impl App {
             confirm_port_input: String::new(),
             confirm_preset: config.preset_for("llama-server"),
             confirm_field: 0,
+            confirm_model_ctx: None,
             confirm_editing: false,
             confirm_edit_buf: String::new(),
             tree_nodes,
@@ -286,6 +264,7 @@ impl App {
             tree_width: 30,
             serve_width: 38,
             log_wrap: false,
+            log_scroll: 0,
             show_tree: true,
             show_serve: false,
             add_dir_input: String::new(),
@@ -364,7 +343,9 @@ impl App {
                     self.tree_cursor += 1;
                 }
             }
-            Focus::Serve => {}
+            Focus::Serve => {
+                self.log_scroll = self.log_scroll.saturating_sub(1);
+            }
         }
     }
 
@@ -381,7 +362,10 @@ impl App {
                     self.tree_cursor -= 1;
                 }
             }
-            Focus::Serve => {}
+            Focus::Serve => {
+                // Clamped to the log length when drawn
+                self.log_scroll = self.log_scroll.saturating_add(1);
+            }
         }
     }
 
@@ -394,7 +378,9 @@ impl App {
             Focus::Tree => {
                 self.tree_cursor = 0;
             }
-            Focus::Serve => {}
+            Focus::Serve => {
+                self.log_scroll = usize::MAX; // clamped to the top when drawn
+            }
         }
     }
 
@@ -411,23 +397,37 @@ impl App {
                     self.tree_cursor = self.tree_nodes.len() - 1;
                 }
             }
-            Focus::Serve => {}
+            Focus::Serve => {
+                self.log_scroll = 0;
+            }
         }
     }
 
     pub fn half_page_down(&mut self) {
-        if self.focus == Focus::Table {
-            let jump = self.visible_rows / 2;
-            self.selected = (self.selected + jump).min(self.filtered.len().saturating_sub(1));
-            self.ensure_visible();
+        match self.focus {
+            Focus::Table => {
+                let jump = self.visible_rows / 2;
+                self.selected = (self.selected + jump).min(self.filtered.len().saturating_sub(1));
+                self.ensure_visible();
+            }
+            Focus::Serve => {
+                self.log_scroll = self.log_scroll.saturating_sub(10);
+            }
+            Focus::Tree => {}
         }
     }
 
     pub fn half_page_up(&mut self) {
-        if self.focus == Focus::Table {
-            let jump = self.visible_rows / 2;
-            self.selected = self.selected.saturating_sub(jump);
-            self.ensure_visible();
+        match self.focus {
+            Focus::Table => {
+                let jump = self.visible_rows / 2;
+                self.selected = self.selected.saturating_sub(jump);
+                self.ensure_visible();
+            }
+            Focus::Serve => {
+                self.log_scroll = self.log_scroll.saturating_add(10);
+            }
+            Focus::Tree => {}
         }
     }
 
@@ -741,6 +741,11 @@ impl App {
             return;
         };
         let format = model.format.clone();
+        let model_ctx = if model.path.extension().is_some_and(|e| e == "gguf") {
+            crate::models::read_gguf_meta(&model.path).and_then(|m| m.context_length)
+        } else {
+            None
+        };
 
         // Pre-select the first compatible + available backend
         let best = self
@@ -751,6 +756,7 @@ impl App {
 
         self.confirm_backend_idx = best;
         self.confirm_port_input = self.next_available_port().to_string();
+        self.confirm_model_ctx = model_ctx;
         self.confirm_field = 0;
         self.confirm_editing = false;
         self.confirm_edit_buf.clear();
@@ -870,6 +876,7 @@ impl App {
         let buf = match self.confirm_selected_field() {
             // Not text-editable
             ConfirmField::Backend | ConfirmField::FlashAttn => return,
+            ConfirmField::Host => self.confirm_preset.host.clone(),
             ConfirmField::Port => self.confirm_port_input.clone(),
             ConfirmField::CtxSize => self.confirm_preset.ctx_size.to_string(),
             ConfirmField::GpuLayers => self
@@ -903,6 +910,7 @@ impl App {
                 (c.is_ascii_digit() || (c == '-' && self.confirm_edit_buf.is_empty()))
                     && self.confirm_edit_buf.len() < 5
             }
+            ConfirmField::Host => !c.is_control() && !c.is_whitespace(),
             ConfirmField::ExtraArgs => !c.is_control(),
             ConfirmField::Backend | ConfirmField::FlashAttn => false,
         };
@@ -920,6 +928,11 @@ impl App {
     pub fn confirm_commit_edit(&mut self) {
         let buf = self.confirm_edit_buf.trim().to_string();
         match self.confirm_selected_field() {
+            ConfirmField::Host => {
+                if !buf.is_empty() {
+                    self.confirm_preset.host = buf;
+                }
+            }
             ConfirmField::Port => {
                 if buf.parse::<u16>().is_ok() {
                     self.confirm_port_input = buf;
@@ -963,6 +976,7 @@ impl App {
         entry.gpu_layers = p.gpu_layers;
         entry.threads = p.threads;
         entry.extra_args = p.extra_args.clone();
+        entry.host = Some(p.host.clone());
         if let Ok(port) = self.confirm_port_input.parse::<u16>() {
             entry.port = Some(port);
         }
@@ -1007,6 +1021,13 @@ impl App {
         let port = self.confirm_port();
         if self.servers.iter().any(|s| s.port == port) {
             self.status_message = Some(format!("Port {port} is already in use"));
+            return;
+        }
+
+        // Also catch ports held by processes outside llmserve (e.g. Ollama),
+        // which would otherwise surface as an instant crash.
+        if !server::port_is_free(&self.confirm_preset.host, port) {
+            self.status_message = Some(format!("Port {port} is already in use by another process"));
             return;
         }
 
@@ -1093,9 +1114,10 @@ impl App {
     // -- Tick --
 
     pub fn tick(&mut self) {
-        // Drain output from all running servers
+        // Drain output from all running servers and probe readiness
         for handle in &mut self.servers {
             handle.drain_output();
+            handle.probe_ready();
         }
 
         // Check for exits
@@ -1109,7 +1131,9 @@ impl App {
             let handle = self.servers.remove(i);
             // Queue a popup so the user sees why the server exited
             self.exit_popups.push_back(ExitInfo {
-                model_name: handle.model_name.clone(),
+                model: handle.model.clone(),
+                backend: handle.backend.clone(),
+                preset: handle.preset.clone(),
                 backend_label: handle.backend.label().to_string(),
                 port: handle.port,
                 message: msg.clone(),
@@ -1170,6 +1194,39 @@ impl App {
         self.exit_popup_scroll = self.exit_popup_scroll.saturating_sub(1);
     }
 
+    /// Relaunch the crashed server with the same model, backend, and settings.
+    pub fn restart_exited(&mut self) {
+        let Some(info) = self.exit_popups.pop_front() else {
+            return;
+        };
+        self.exit_popup_scroll = 0;
+        if self.exit_popups.is_empty() {
+            self.input_mode = InputMode::Normal;
+        }
+
+        if !server::port_is_free(&info.preset.host, info.preset.port) {
+            self.status_message = Some(format!(
+                "Cannot restart: port {} is already in use",
+                info.preset.port
+            ));
+            return;
+        }
+
+        match server::launch_with(&info.model, &info.backend, &info.preset) {
+            Ok(handle) => {
+                self.status_message = Some(format!(
+                    "Restarted {} on port {}",
+                    handle.model_name, handle.port
+                ));
+                self.servers.push(handle);
+                self.show_serve = true;
+            }
+            Err(e) => {
+                self.status_message = Some(e);
+            }
+        }
+    }
+
     /// Get all log lines to display — combines live server logs and dead logs.
     pub fn all_log_lines(&self) -> Vec<(&str, &str)> {
         let mut lines = Vec::new();
@@ -1194,6 +1251,7 @@ impl App {
 
     pub fn clear_dead_logs(&mut self) {
         self.dead_logs.clear();
+        self.log_scroll = 0;
     }
 
     /// Whether there are any logs to show (live or dead).
@@ -1211,55 +1269,7 @@ impl App {
 
     fn rebuild_models(&mut self) {
         self.models = discover_models(&self.config.extra_model_dirs);
-
-        if let Some(ollama) = self.backends.iter().find(|b| b.backend == Backend::Ollama) {
-            if ollama.available {
-                if let Some(ref url) = ollama.api_url {
-                    let ollama_models = fetch_ollama_models(url);
-                    add_ollama_models(&mut self.models, ollama_models);
-                }
-            }
-        }
-
-        if let Some(lmstudio) = self
-            .backends
-            .iter()
-            .find(|b| b.backend == Backend::LmStudio)
-        {
-            if lmstudio.available {
-                if let Some(ref url) = lmstudio.api_url {
-                    let lmstudio_models = fetch_lmstudio_models(url);
-                    add_lmstudio_models(&mut self.models, lmstudio_models);
-                }
-            }
-        }
-
-        if let Some(lemonade) = self
-            .backends
-            .iter()
-            .find(|b| b.backend == Backend::Lemonade)
-        {
-            if lemonade.available {
-                if let Some(ref url) = lemonade.api_url {
-                    let lemonade_models = fetch_lemonade_models(url);
-                    add_lemonade_models(&mut self.models, lemonade_models);
-                }
-            }
-        }
-
-        if let Some(flm) = self
-            .backends
-            .iter()
-            .find(|b| b.backend == Backend::FastFlowLm)
-        {
-            if flm.available {
-                if let Some(ref url) = flm.api_url {
-                    let flm_models = fetch_fastflowlm_models(url);
-                    add_fastflowlm_models(&mut self.models, flm_models);
-                }
-            }
-        }
-
+        fetch_api_models(&self.backends, &mut self.models);
         self.tree_nodes = build_tree(&self.models, &self.config);
         self.apply_filters();
     }
@@ -1274,6 +1284,49 @@ impl App {
 
 fn first_available(backends: &[DetectedBackend]) -> usize {
     backends.iter().position(|b| b.available).unwrap_or(0)
+}
+
+/// Fetch model lists from all available API-backed backends concurrently
+/// (each fetch has an 800ms timeout, so serial fetching would stack up)
+/// and merge them into `models`.
+fn fetch_api_models(backends: &[DetectedBackend], models: &mut Vec<DiscoveredModel>) {
+    let url_for = |backend: Backend| {
+        backends
+            .iter()
+            .find(|d| d.backend == backend)
+            .filter(|d| d.available)
+            .and_then(|d| d.api_url.clone())
+    };
+    let ollama_url = url_for(Backend::Ollama);
+    let lmstudio_url = url_for(Backend::LmStudio);
+    let lemonade_url = url_for(Backend::Lemonade);
+    let flm_url = url_for(Backend::FastFlowLm);
+
+    let (ollama, lmstudio, lemonade, flm) = std::thread::scope(|s| {
+        let ollama = s.spawn(|| ollama_url.as_deref().map(fetch_ollama_models));
+        let lmstudio = s.spawn(|| lmstudio_url.as_deref().map(fetch_lmstudio_models));
+        let lemonade = s.spawn(|| lemonade_url.as_deref().map(fetch_lemonade_models));
+        let flm = s.spawn(|| flm_url.as_deref().map(fetch_fastflowlm_models));
+        (
+            ollama.join().ok().flatten(),
+            lmstudio.join().ok().flatten(),
+            lemonade.join().ok().flatten(),
+            flm.join().ok().flatten(),
+        )
+    });
+
+    if let Some(list) = ollama {
+        add_ollama_models(models, list);
+    }
+    if let Some(list) = lmstudio {
+        add_lmstudio_models(models, list);
+    }
+    if let Some(list) = lemonade {
+        add_lemonade_models(models, list);
+    }
+    if let Some(list) = flm {
+        add_fastflowlm_models(models, list);
+    }
 }
 
 /// Build the source tree from discovered models.

--- a/src/backends.rs
+++ b/src/backends.rs
@@ -88,17 +88,33 @@ fn http_agent() -> ureq::Agent {
 }
 
 pub fn detect_backends() -> Vec<DetectedBackend> {
-    vec![
-        detect_llama_server(),
-        detect_ollama(),
-        detect_mlx(),
-        detect_lmstudio(),
-        detect_vllm(),
-        detect_koboldcpp(),
-        detect_localai(),
-        detect_lemonade(),
-        detect_fastflowlm(),
-    ]
+    // Several detectors make HTTP probes with an 800ms timeout; run them all
+    // concurrently so detection costs one probe's latency, not the sum.
+    let detectors: [(Backend, fn() -> DetectedBackend); 9] = [
+        (Backend::LlamaServer, detect_llama_server),
+        (Backend::Ollama, detect_ollama),
+        (Backend::MlxLm, detect_mlx),
+        (Backend::LmStudio, detect_lmstudio),
+        (Backend::Vllm, detect_vllm),
+        (Backend::KoboldCpp, detect_koboldcpp),
+        (Backend::LocalAi, detect_localai),
+        (Backend::Lemonade, detect_lemonade),
+        (Backend::FastFlowLm, detect_fastflowlm),
+    ];
+    std::thread::scope(|s| {
+        detectors
+            .map(|(backend, f)| (backend, s.spawn(f)))
+            .map(|(backend, h)| {
+                h.join().unwrap_or(DetectedBackend {
+                    backend,
+                    available: false,
+                    binary_path: None,
+                    api_url: None,
+                })
+            })
+            .into_iter()
+            .collect()
+    })
 }
 
 /// Cross-platform binary lookup. Uses `which` on Unix and `where` on Windows.
@@ -221,10 +237,10 @@ fn detect_lmstudio() -> DetectedBackend {
     }
 }
 
-/// Returns LM Studio model list from API: Vec<(id, size_bytes)>
-/// LM Studio exposes an OpenAI-compatible /v1/models endpoint.
-pub fn fetch_lmstudio_models(api_url: &str) -> Vec<(String, u64)> {
-    let url = format!("{api_url}/v1/models");
+/// Fetch the model list from an OpenAI-compatible `models` endpoint:
+/// returns Vec<(id, size_bytes)> (size is not exposed by these APIs).
+fn fetch_openai_models(api_url: &str, path: &str) -> Vec<(String, u64)> {
+    let url = format!("{api_url}{path}");
     let agent = http_agent();
     let Ok(mut response) = agent.get(&url).call() else {
         return Vec::new();
@@ -244,6 +260,11 @@ pub fn fetch_lmstudio_models(api_url: &str) -> Vec<(String, u64)> {
             Some((id, 0u64))
         })
         .collect()
+}
+
+/// Returns LM Studio model list from its OpenAI-compatible /v1/models endpoint.
+pub fn fetch_lmstudio_models(api_url: &str) -> Vec<(String, u64)> {
+    fetch_openai_models(api_url, "/v1/models")
 }
 
 fn detect_vllm() -> DetectedBackend {
@@ -295,29 +316,9 @@ fn detect_lemonade() -> DetectedBackend {
     }
 }
 
-/// Returns Lemonade model list from API: Vec<(id, size_bytes)>
-/// Lemonade exposes an OpenAI-compatible /api/v1/models endpoint.
+/// Returns Lemonade model list from its OpenAI-compatible /api/v1/models endpoint.
 pub fn fetch_lemonade_models(api_url: &str) -> Vec<(String, u64)> {
-    let url = format!("{api_url}/api/v1/models");
-    let agent = http_agent();
-    let Ok(mut response) = agent.get(&url).call() else {
-        return Vec::new();
-    };
-    let Ok(body) = response.body_mut().read_to_string() else {
-        return Vec::new();
-    };
-    let Ok(json) = serde_json::from_str::<serde_json::Value>(&body) else {
-        return Vec::new();
-    };
-    let Some(data) = json.get("data").and_then(|d| d.as_array()) else {
-        return Vec::new();
-    };
-    data.iter()
-        .filter_map(|m| {
-            let id = m.get("id")?.as_str()?.to_string();
-            Some((id, 0u64))
-        })
-        .collect()
+    fetch_openai_models(api_url, "/api/v1/models")
 }
 
 fn detect_fastflowlm() -> DetectedBackend {
@@ -336,29 +337,9 @@ fn detect_fastflowlm() -> DetectedBackend {
     }
 }
 
-/// Returns FastFlowLM model list from API: Vec<(id, size_bytes)>
-/// FastFlowLM exposes an OpenAI-compatible /v1/models endpoint.
+/// Returns FastFlowLM model list from its OpenAI-compatible /v1/models endpoint.
 pub fn fetch_fastflowlm_models(api_url: &str) -> Vec<(String, u64)> {
-    let url = format!("{api_url}/v1/models");
-    let agent = http_agent();
-    let Ok(mut response) = agent.get(&url).call() else {
-        return Vec::new();
-    };
-    let Ok(body) = response.body_mut().read_to_string() else {
-        return Vec::new();
-    };
-    let Ok(json) = serde_json::from_str::<serde_json::Value>(&body) else {
-        return Vec::new();
-    };
-    let Some(data) = json.get("data").and_then(|d| d.as_array()) else {
-        return Vec::new();
-    };
-    data.iter()
-        .filter_map(|m| {
-            let id = m.get("id")?.as_str()?.to_string();
-            Some((id, 0u64))
-        })
-        .collect()
+    fetch_openai_models(api_url, "/v1/models")
 }
 
 fn detect_localai() -> DetectedBackend {

--- a/src/events.rs
+++ b/src/events.rs
@@ -164,6 +164,7 @@ fn handle_stop_popup(app: &mut App, key: KeyEvent) {
 fn handle_server_exit_popup(app: &mut App, key: KeyEvent) {
     match key.code {
         KeyCode::Esc | KeyCode::Enter | KeyCode::Char('q') => app.dismiss_exit_popup(),
+        KeyCode::Char('r') => app.restart_exited(),
         KeyCode::Down | KeyCode::Char('j') => app.exit_popup_scroll_down(),
         KeyCode::Up | KeyCode::Char('k') => app.exit_popup_scroll_up(),
         _ => {}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,5 @@
 use std::io;
 
-use crossterm::event::{DisableMouseCapture, EnableMouseCapture};
 use crossterm::execute;
 use crossterm::terminal::{
     EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode,
@@ -12,21 +11,69 @@ use llmserve::app::App;
 use llmserve::events::handle_events;
 use llmserve::ui;
 
+const HELP: &str = "\
+llmserve — TUI for discovering local LLM models and serving them
+
+Usage: llmserve [OPTIONS]
+
+Options:
+  -h, --help     Print this help
+  -V, --version  Print version
+
+Keys (in the TUI):
+  Tab        cycle panel focus          /   search models
+  j/k        navigate                   f   cycle format filter
+  Enter      serve selected model       o   cycle sort order
+  s / S      stop server / stop all     b   select backend
+  a / x      add / remove model dir     r   rescan models & backends
+  1 / 3      toggle sources / logs      t   cycle theme
+  q          quit
+
+Config: ~/.config/llmserve/config.toml";
+
+/// Restore the terminal even if we panic, so the user's shell isn't left in
+/// raw mode on the alternate screen with no cursor.
+fn install_panic_hook() {
+    let original = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        let _ = disable_raw_mode();
+        let _ = execute!(io::stdout(), LeaveAlternateScreen);
+        original(info);
+    }));
+}
+
 fn main() -> io::Result<()> {
+    if let Some(arg) = std::env::args().nth(1) {
+        match arg.as_str() {
+            "-V" | "--version" => {
+                println!("llmserve {}", env!("CARGO_PKG_VERSION"));
+                return Ok(());
+            }
+            "-h" | "--help" => {
+                println!("{HELP}");
+                return Ok(());
+            }
+            other => {
+                eprintln!("Unknown option: {other}\nTry 'llmserve --help'");
+                std::process::exit(2);
+            }
+        }
+    }
+
+    install_panic_hook();
+
     enable_raw_mode()?;
     let mut stdout = io::stdout();
-    execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
+    // Note: mouse capture is deliberately not enabled — it would prevent
+    // normal terminal text selection (copying URLs or log lines).
+    execute!(stdout, EnterAlternateScreen)?;
     let backend = CrosstermBackend::new(stdout);
     let mut terminal = Terminal::new(backend)?;
 
     let result = run(&mut terminal);
 
     disable_raw_mode()?;
-    execute!(
-        terminal.backend_mut(),
-        LeaveAlternateScreen,
-        DisableMouseCapture
-    )?;
+    execute!(terminal.backend_mut(), LeaveAlternateScreen)?;
     terminal.show_cursor()?;
 
     if let Err(e) = result {

--- a/src/models.rs
+++ b/src/models.rs
@@ -201,6 +201,11 @@ fn scan_gguf_dir(
             };
             let param_source = if parent == dir { &file_stem } else { &dir_name };
 
+            // Prefer the filename hint (free); fall back to the GGUF header's
+            // size label for files with uninformative names.
+            let param_hint = parse_params(param_source)
+                .or_else(|| read_gguf_meta(path).and_then(|m| m.size_label));
+
             models.push(DiscoveredModel {
                 name,
                 path: path.to_path_buf(),
@@ -208,7 +213,7 @@ fn scan_gguf_dir(
                 format: ModelFormat::Gguf,
                 size_bytes,
                 quant: parse_quant(&fname),
-                param_hint: parse_params(param_source),
+                param_hint,
                 source: source.clone(),
             });
         }
@@ -404,6 +409,185 @@ pub fn add_ollama_models(models: &mut Vec<DiscoveredModel>, ollama_models: Vec<(
         });
     }
     models.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
+}
+
+// -- GGUF header parsing --
+//
+// Just enough of the GGUF format to pull display metadata out of the header:
+// magic, version, counts, then key/value pairs. Values we don't care about
+// (including the huge tokenizer arrays) are skipped by seeking, so this reads
+// a few KB regardless of model size.
+
+/// Metadata extracted from a GGUF file header.
+#[derive(Debug, Clone, Default)]
+pub struct GgufMeta {
+    pub architecture: Option<String>,
+    pub context_length: Option<u64>,
+    /// Parameter-count label as written by the converter, e.g. "4B", "8x7B".
+    pub size_label: Option<String>,
+}
+
+pub fn read_gguf_meta(path: &Path) -> Option<GgufMeta> {
+    use std::io::BufReader;
+    let file = fs::File::open(path).ok()?;
+    let mut r = BufReader::new(file);
+
+    let mut magic = [0u8; 4];
+    std::io::Read::read_exact(&mut r, &mut magic).ok()?;
+    if &magic != b"GGUF" {
+        return None;
+    }
+    let version = read_u32(&mut r)?;
+    if !(1..=3).contains(&version) {
+        return None;
+    }
+    let _tensor_count = read_u64(&mut r)?;
+    let kv_count = read_u64(&mut r)?;
+
+    let mut meta = GgufMeta::default();
+
+    // Cap iterations defensively against corrupt headers.
+    for _ in 0..kv_count.min(1024) {
+        let Some(key) = read_gguf_string(&mut r, 1024) else {
+            return Some(meta); // corrupt or oversized key — keep what we have
+        };
+        let vtype = read_u32(&mut r)?;
+
+        // Every arm consumes the value (reading it or seeking past it).
+        match key.as_str() {
+            "general.architecture" if vtype == GGUF_TYPE_STRING => {
+                meta.architecture = read_gguf_string(&mut r, 256);
+            }
+            "general.size_label" if vtype == GGUF_TYPE_STRING => {
+                meta.size_label = read_gguf_string(&mut r, 64);
+            }
+            k if k.ends_with(".context_length") => {
+                if let Some(v) = read_gguf_uint(&mut r, vtype) {
+                    meta.context_length = Some(v);
+                }
+            }
+            _ => skip_gguf_value(&mut r, vtype)?,
+        }
+
+        if meta.architecture.is_some() && meta.context_length.is_some() && meta.size_label.is_some()
+        {
+            break;
+        }
+    }
+    Some(meta)
+}
+
+const GGUF_TYPE_STRING: u32 = 8;
+const GGUF_TYPE_ARRAY: u32 = 9;
+
+fn read_u32(r: &mut impl std::io::Read) -> Option<u32> {
+    let mut b = [0u8; 4];
+    r.read_exact(&mut b).ok()?;
+    Some(u32::from_le_bytes(b))
+}
+
+fn read_u64(r: &mut impl std::io::Read) -> Option<u64> {
+    let mut b = [0u8; 8];
+    r.read_exact(&mut b).ok()?;
+    Some(u64::from_le_bytes(b))
+}
+
+fn skip_bytes<R: std::io::Read + std::io::Seek>(
+    r: &mut std::io::BufReader<R>,
+    n: u64,
+) -> Option<()> {
+    let n: i64 = n.try_into().ok()?;
+    r.seek_relative(n).ok()
+}
+
+/// Read a length-prefixed GGUF string, or skip it (returning None) if it
+/// exceeds `cap` bytes.
+fn read_gguf_string<R: std::io::Read + std::io::Seek>(
+    r: &mut std::io::BufReader<R>,
+    cap: u64,
+) -> Option<String> {
+    let len = read_u64(r)?;
+    if len > cap {
+        skip_bytes(r, len)?;
+        return None;
+    }
+    let mut buf = vec![0u8; len as usize];
+    std::io::Read::read_exact(r, &mut buf).ok()?;
+    Some(String::from_utf8_lossy(&buf).into_owned())
+}
+
+/// Read an unsigned integer value of the given GGUF type; skips the value and
+/// returns None for non-integer types.
+fn read_gguf_uint<R: std::io::Read + std::io::Seek>(
+    r: &mut std::io::BufReader<R>,
+    vtype: u32,
+) -> Option<u64> {
+    match vtype {
+        0 => {
+            // u8
+            let mut b = [0u8; 1];
+            std::io::Read::read_exact(r, &mut b).ok()?;
+            Some(b[0] as u64)
+        }
+        2 => {
+            // u16
+            let mut b = [0u8; 2];
+            std::io::Read::read_exact(r, &mut b).ok()?;
+            Some(u16::from_le_bytes(b) as u64)
+        }
+        4 => read_u32(r).map(u64::from),
+        10 => read_u64(r),
+        5 => {
+            // i32 — context lengths are sometimes written signed
+            read_u32(r)
+                .map(|v| v as i32)
+                .filter(|v| *v >= 0)
+                .map(|v| v as u64)
+        }
+        11 => read_u64(r)
+            .map(|v| v as i64)
+            .filter(|v| *v >= 0)
+            .map(|v| v as u64),
+        _ => {
+            skip_gguf_value(r, vtype)?;
+            None
+        }
+    }
+}
+
+fn skip_gguf_value<R: std::io::Read + std::io::Seek>(
+    r: &mut std::io::BufReader<R>,
+    vtype: u32,
+) -> Option<()> {
+    match vtype {
+        0 | 1 | 7 => skip_bytes(r, 1),
+        2 | 3 => skip_bytes(r, 2),
+        4 | 5 | 6 => skip_bytes(r, 4),
+        10 | 11 | 12 => skip_bytes(r, 8),
+        GGUF_TYPE_STRING => {
+            let len = read_u64(r)?;
+            skip_bytes(r, len)
+        }
+        GGUF_TYPE_ARRAY => {
+            let elem = read_u32(r)?;
+            let count = read_u64(r)?;
+            match elem {
+                0 | 1 | 7 => skip_bytes(r, count),
+                2 | 3 => skip_bytes(r, count.checked_mul(2)?),
+                4 | 5 | 6 => skip_bytes(r, count.checked_mul(4)?),
+                10 | 11 | 12 => skip_bytes(r, count.checked_mul(8)?),
+                GGUF_TYPE_STRING => {
+                    for _ in 0..count {
+                        let len = read_u64(r)?;
+                        skip_bytes(r, len)?;
+                    }
+                    Some(())
+                }
+                _ => None, // nested arrays are not produced by converters
+            }
+        }
+        _ => None,
+    }
 }
 
 fn find_mmproj(dir: &Path) -> Option<PathBuf> {
@@ -637,6 +821,74 @@ mod tests {
         assert_eq!(names.len(), 2, "names should be distinct, got: {names:?}");
 
         fs::remove_dir_all(&tmp).unwrap();
+    }
+
+    /// Build a minimal synthetic GGUF header for parser tests.
+    fn synth_gguf(kvs: &[(&str, u32, Vec<u8>)]) -> Vec<u8> {
+        let mut b = Vec::new();
+        b.extend(b"GGUF");
+        b.extend(3u32.to_le_bytes()); // version
+        b.extend(0u64.to_le_bytes()); // tensor count
+        b.extend((kvs.len() as u64).to_le_bytes());
+        for (key, vtype, value) in kvs {
+            b.extend((key.len() as u64).to_le_bytes());
+            b.extend(key.as_bytes());
+            b.extend(vtype.to_le_bytes());
+            b.extend(value);
+        }
+        b
+    }
+
+    fn gguf_string(s: &str) -> Vec<u8> {
+        let mut v = (s.len() as u64).to_le_bytes().to_vec();
+        v.extend(s.as_bytes());
+        v
+    }
+
+    #[test]
+    fn read_gguf_meta_extracts_fields() {
+        // Include a string array (like a tokenizer vocab) to prove skipping works
+        let mut vocab = Vec::new();
+        vocab.extend(8u32.to_le_bytes()); // elem type: string
+        vocab.extend(3u64.to_le_bytes()); // count
+        for word in ["alpha", "beta", "gamma"] {
+            vocab.extend(gguf_string(word));
+        }
+
+        let bytes = synth_gguf(&[
+            ("general.architecture", 8, gguf_string("gemma3")),
+            ("tokenizer.ggml.tokens", 9, vocab),
+            ("gemma3.context_length", 4, 131072u32.to_le_bytes().to_vec()),
+            ("general.size_label", 8, gguf_string("4B")),
+        ]);
+
+        let tmp = std::env::temp_dir().join(format!("llmserve_gguf_{}.gguf", std::process::id()));
+        fs::write(&tmp, bytes).unwrap();
+        let meta = read_gguf_meta(&tmp).expect("should parse");
+        fs::remove_file(&tmp).unwrap();
+
+        assert_eq!(meta.architecture.as_deref(), Some("gemma3"));
+        assert_eq!(meta.context_length, Some(131072));
+        assert_eq!(meta.size_label.as_deref(), Some("4B"));
+    }
+
+    #[test]
+    fn read_gguf_meta_rejects_non_gguf() {
+        let tmp =
+            std::env::temp_dir().join(format!("llmserve_notgguf_{}.gguf", std::process::id()));
+        fs::write(&tmp, b"this is not a gguf file at all").unwrap();
+        assert!(read_gguf_meta(&tmp).is_none());
+        fs::remove_file(&tmp).unwrap();
+    }
+
+    #[test]
+    fn read_gguf_meta_survives_truncated_header() {
+        let bytes = synth_gguf(&[("general.architecture", 8, gguf_string("llama"))]);
+        let tmp = std::env::temp_dir().join(format!("llmserve_trunc_{}.gguf", std::process::id()));
+        // Truncate mid-header: parser should return what it has or None, not panic
+        fs::write(&tmp, &bytes[..bytes.len() / 2]).unwrap();
+        let _ = read_gguf_meta(&tmp);
+        fs::remove_file(&tmp).unwrap();
     }
 
     #[test]

--- a/src/server.rs
+++ b/src/server.rs
@@ -3,10 +3,21 @@ use crate::config::{Config, ResolvedPreset};
 use crate::models::DiscoveredModel;
 use std::collections::VecDeque;
 use std::io::Read;
+use std::net::TcpListener;
 use std::process::{Child, Command, Stdio};
-use std::time::Instant;
+use std::sync::mpsc::{Receiver, Sender, channel};
+use std::thread::JoinHandle;
+use std::time::{Duration, Instant};
 
-const MAX_LOG_LINES: usize = 200;
+const MAX_LOG_LINES: usize = 1000;
+
+/// A chunk of child output forwarded from a reader thread.
+enum LogMsg {
+    /// A complete, newline-terminated line.
+    Line(String),
+    /// A carriage-return progress update that should replace the previous one.
+    Progress(String),
+}
 
 pub struct ServerHandle {
     pub backend: Backend,
@@ -16,10 +27,18 @@ pub struct ServerHandle {
     pub host: String,
     pub child: Child,
     pub started_at: Instant,
+    /// Whether the server has started accepting TCP connections.
+    pub ready: bool,
+    /// The model and preset used to launch, kept so a crashed server can be
+    /// relaunched with identical settings.
+    pub model: DiscoveredModel,
+    pub preset: ResolvedPreset,
     /// Ring buffer of log lines (combined stdout + stderr).
     pub log_lines: VecDeque<String>,
-    /// Partial line buffer for incomplete reads.
-    partial: String,
+    rx: Receiver<LogMsg>,
+    readers: Vec<JoinHandle<()>>,
+    last_probe: Option<Instant>,
+    last_was_progress: bool,
 }
 
 impl ServerHandle {
@@ -38,123 +57,162 @@ impl ServerHandle {
         format!("http://{}:{}", self.host, self.port)
     }
 
-    /// Read any available output from stderr (non-blocking).
+    /// Pull any output forwarded by the reader threads into the ring buffer.
     pub fn drain_output(&mut self) {
-        let Some(stderr) = self.child.stderr.as_mut() else {
-            return;
-        };
-
-        let mut buf = [0u8; 4096];
-        // Non-blocking read — will return WouldBlock if nothing available
-        loop {
-            match stderr.read(&mut buf) {
-                Ok(0) => break, // EOF
-                Ok(n) => {
-                    let chunk = String::from_utf8_lossy(&buf[..n]);
-                    self.partial.push_str(&chunk);
-
-                    // Split into complete lines
-                    while let Some(pos) = self.partial.find('\n') {
-                        let line: String = self.partial.drain(..=pos).collect();
-                        let line = line.trim_end_matches('\n').trim_end_matches('\r');
-                        self.log_lines.push_back(line.to_string());
-                        if self.log_lines.len() > MAX_LOG_LINES {
-                            self.log_lines.pop_front();
-                        }
-                    }
-
-                    // Handle \r (carriage return) for progress lines
-                    if self.partial.contains('\r') {
-                        let last = self.partial.rsplit('\r').next().unwrap_or("").to_string();
-                        if !last.is_empty() {
-                            // Replace last line if it was a progress update
-                            if let Some(back) = self.log_lines.back_mut() {
-                                if back.contains('\r') || back.contains('%') || back.contains("...")
-                                {
-                                    *back = last.clone();
-                                } else {
-                                    self.log_lines.push_back(last.clone());
-                                }
-                            } else {
-                                self.log_lines.push_back(last.clone());
-                            }
-                        }
-                        self.partial.clear();
-                        self.partial.push_str(&last);
-                    }
-                }
-                Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => break,
-                Err(_) => break,
-            }
+        while let Ok(msg) = self.rx.try_recv() {
+            self.apply_log(msg);
         }
+    }
 
-        // Also try stdout
-        let Some(stdout) = self.child.stdout.as_mut() else {
-            return;
+    fn apply_log(&mut self, msg: LogMsg) {
+        let (text, is_progress) = match msg {
+            LogMsg::Line(l) => (l, false),
+            LogMsg::Progress(p) => (p, true),
         };
-        loop {
-            match stdout.read(&mut buf) {
-                Ok(0) => break,
-                Ok(n) => {
-                    let chunk = String::from_utf8_lossy(&buf[..n]);
-                    for line in chunk.lines() {
-                        self.log_lines.push_back(line.to_string());
-                        if self.log_lines.len() > MAX_LOG_LINES {
-                            self.log_lines.pop_front();
-                        }
-                    }
-                }
-                Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => break,
-                Err(_) => break,
+        // A progress update — or the final line completing one — replaces the
+        // previous progress line instead of appending.
+        if self.last_was_progress {
+            if let Some(back) = self.log_lines.back_mut() {
+                *back = text;
+            } else {
+                self.log_lines.push_back(text);
             }
+        } else {
+            self.log_lines.push_back(text);
+        }
+        self.last_was_progress = is_progress;
+        while self.log_lines.len() > MAX_LOG_LINES {
+            self.log_lines.pop_front();
+        }
+    }
+
+    /// Probe whether the server is ready to answer requests (at most once per
+    /// second, and never again once it succeeds). Uses HTTP /health rather
+    /// than a bare TCP connect: llama-server opens its listener before the
+    /// model finishes loading and answers 503 until it's actually ready.
+    /// Backends without a /health endpoint answer 404, which still proves
+    /// the server is up.
+    pub fn probe_ready(&mut self) {
+        if self.ready {
+            return;
+        }
+        let due = self
+            .last_probe
+            .is_none_or(|t| t.elapsed() >= Duration::from_secs(1));
+        if !due {
+            return;
+        }
+        self.last_probe = Some(Instant::now());
+        let host = if self.host == "0.0.0.0" {
+            "127.0.0.1"
+        } else {
+            self.host.as_str()
+        };
+        let agent: ureq::Agent = ureq::Agent::config_builder()
+            .timeout_global(Some(Duration::from_millis(150)))
+            .build()
+            .new_agent();
+        match agent
+            .get(format!("http://{host}:{}/health", self.port))
+            .call()
+        {
+            Ok(_) => self.ready = true,
+            // Any HTTP answer means the server is up; 503 specifically means
+            // "still loading" (llama-server semantics), so keep waiting.
+            Err(ureq::Error::StatusCode(code)) if code != 503 => self.ready = true,
+            Err(_) => {}
+        }
+    }
+
+    /// Wait for the reader threads to finish flushing (call after the child
+    /// has exited or been killed, so they see EOF promptly).
+    fn join_readers(&mut self) {
+        for h in self.readers.drain(..) {
+            let _ = h.join();
         }
     }
 }
 
-fn set_nonblocking(child: &mut Child) {
-    #[cfg(unix)]
-    {
-        use std::os::unix::io::AsRawFd;
-        if let Some(ref stderr) = child.stderr {
-            let fd = stderr.as_raw_fd();
-            unsafe {
-                let flags = libc::fcntl(fd, libc::F_GETFL);
-                libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK);
-            }
-        }
-        if let Some(ref stdout) = child.stdout {
-            let fd = stdout.as_raw_fd();
-            unsafe {
-                let flags = libc::fcntl(fd, libc::F_GETFL);
-                libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK);
-            }
-        }
-    }
+/// Read a child pipe on a dedicated thread, forwarding complete lines and
+/// carriage-return progress updates. Blocking reads are fine here — the
+/// thread exits on EOF when the child dies. This is portable (no fcntl),
+/// so serving works on Windows too.
+fn spawn_reader<R: Read + Send + 'static>(mut src: R, tx: Sender<LogMsg>) -> JoinHandle<()> {
+    std::thread::spawn(move || {
+        let mut partial = String::new();
+        let mut buf = [0u8; 4096];
+        loop {
+            match src.read(&mut buf) {
+                Ok(0) | Err(_) => break,
+                Ok(n) => {
+                    partial.push_str(&String::from_utf8_lossy(&buf[..n]));
 
-    // Windows: would need winapi/windows-sys crate for SetNamedPipeHandleState(PIPE_NOWAIT)
-    #[cfg(windows)]
-    let _ = child;
+                    while let Some(pos) = partial.find('\n') {
+                        let line: String = partial.drain(..=pos).collect();
+                        let line = line.trim_end_matches('\n').trim_end_matches('\r');
+                        // Keep only the final segment of any in-line \r updates
+                        let line = line.rsplit('\r').next().unwrap_or(line);
+                        if tx.send(LogMsg::Line(line.to_string())).is_err() {
+                            return;
+                        }
+                    }
+
+                    if partial.contains('\r') {
+                        let last = partial.rsplit('\r').next().unwrap_or("").to_string();
+                        if !last.is_empty() && tx.send(LogMsg::Progress(last.clone())).is_err() {
+                            return;
+                        }
+                        partial.clear();
+                        partial.push_str(&last);
+                    }
+                }
+            }
+        }
+        let rest = partial.trim();
+        if !rest.is_empty() {
+            let _ = tx.send(LogMsg::Line(rest.to_string()));
+        }
+    })
+}
+
+/// Check whether a port can be bound on the given host (i.e. nothing else —
+/// including processes outside llmserve — is already listening on it).
+pub fn port_is_free(host: &str, port: u16) -> bool {
+    TcpListener::bind((host, port)).is_ok()
 }
 
 fn make_handle(
     backend: Backend,
     model: &DiscoveredModel,
-    port: u16,
-    host: String,
+    preset: &ResolvedPreset,
     mut child: Child,
 ) -> ServerHandle {
-    set_nonblocking(&mut child);
+    let (tx, rx) = channel();
+    let mut readers = Vec::new();
+    if let Some(stderr) = child.stderr.take() {
+        readers.push(spawn_reader(stderr, tx.clone()));
+    }
+    if let Some(stdout) = child.stdout.take() {
+        readers.push(spawn_reader(stdout, tx));
+    }
+
     let pid = child.id();
     ServerHandle {
         backend,
         model_name: model.name.clone(),
         pid,
-        port,
-        host,
+        port: preset.port,
+        host: preset.host.clone(),
         child,
         started_at: Instant::now(),
+        ready: false,
+        model: model.clone(),
+        preset: preset.clone(),
         log_lines: VecDeque::new(),
-        partial: String::new(),
+        rx,
+        readers,
+        last_probe: None,
+        last_was_progress: false,
     }
 }
 
@@ -270,13 +328,7 @@ fn launch_llama_server(
         .spawn()
         .map_err(|e| format!("Failed to start llama-server: {e}"))?;
 
-    Ok(make_handle(
-        Backend::LlamaServer,
-        model,
-        preset.port,
-        preset.host.clone(),
-        child,
-    ))
+    Ok(make_handle(Backend::LlamaServer, model, preset, child))
 }
 
 fn launch_mlx(model: &DiscoveredModel, preset: &ResolvedPreset) -> Result<ServerHandle, String> {
@@ -298,13 +350,7 @@ fn launch_mlx(model: &DiscoveredModel, preset: &ResolvedPreset) -> Result<Server
         .spawn()
         .map_err(|e| format!("Failed to start mlx_lm.server: {e}"))?;
 
-    Ok(make_handle(
-        Backend::MlxLm,
-        model,
-        preset.port,
-        preset.host.clone(),
-        child,
-    ))
+    Ok(make_handle(Backend::MlxLm, model, preset, child))
 }
 
 fn launch_koboldcpp(
@@ -341,13 +387,7 @@ fn launch_koboldcpp(
         .spawn()
         .map_err(|e| format!("Failed to start koboldcpp: {e}"))?;
 
-    Ok(make_handle(
-        Backend::KoboldCpp,
-        model,
-        preset.port,
-        preset.host.clone(),
-        child,
-    ))
+    Ok(make_handle(Backend::KoboldCpp, model, preset, child))
 }
 
 fn launch_localai(
@@ -386,13 +426,7 @@ fn launch_localai(
         .spawn()
         .map_err(|e| format!("Failed to start local-ai: {e}"))?;
 
-    Ok(make_handle(
-        Backend::LocalAi,
-        model,
-        preset.port,
-        preset.host.clone(),
-        child,
-    ))
+    Ok(make_handle(Backend::LocalAi, model, preset, child))
 }
 
 fn launch_lemonade(
@@ -421,26 +455,36 @@ fn launch_lemonade(
         .spawn()
         .map_err(|e| format!("Failed to start lemonade: {e}"))?;
 
-    Ok(make_handle(
-        Backend::Lemonade,
-        model,
-        preset.port,
-        preset.host.clone(),
-        child,
-    ))
+    Ok(make_handle(Backend::Lemonade, model, preset, child))
 }
 
 pub fn stop(handle: &mut ServerHandle) {
-    // Drain any remaining output before killing
-    handle.drain_output();
+    // Ask nicely first so the backend can release its port and clean up,
+    // then force-kill if it hasn't exited within the grace period.
+    #[cfg(unix)]
+    {
+        unsafe {
+            libc::kill(handle.pid as libc::pid_t, libc::SIGTERM);
+        }
+        for _ in 0..20 {
+            if matches!(handle.child.try_wait(), Ok(Some(_))) {
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(100));
+        }
+    }
     let _ = handle.child.kill();
     let _ = handle.child.wait();
+    handle.join_readers();
+    handle.drain_output();
 }
 
 pub fn check_exited(handle: &mut ServerHandle) -> Option<String> {
     match handle.child.try_wait() {
         Ok(Some(status)) => {
-            // Final drain
+            // The pipes are closed now; wait for the readers to flush the
+            // final output so the exit popup shows the actual error.
+            handle.join_readers();
             handle.drain_output();
             if status.success() {
                 Some("Server exited normally".into())

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -252,7 +252,6 @@ fn draw_model_table(frame: &mut Frame, app: &mut App, area: Rect, tc: &ThemeColo
         .map(|(display_idx, &model_idx)| {
             let m = &app.models[model_idx];
             let is_selected = focused && display_idx == app.selected;
-            let is_serving = app.is_model_served(&m.name);
 
             let style = if is_selected {
                 Style::default().bg(tc.highlight_bg).fg(tc.fg)
@@ -262,16 +261,16 @@ fn draw_model_table(frame: &mut Frame, app: &mut App, area: Rect, tc: &ThemeColo
 
             let vision = if m.mmproj.is_some() { " [V]" } else { "" };
 
-            let status = if is_serving {
-                let srv = app.servers.iter().find(|s| s.model_name == m.name).unwrap();
-                format!(":{} ({})", srv.port, srv.backend.label())
-            } else {
-                String::new()
+            let srv = app.servers.iter().find(|s| s.model_name == m.name);
+            let status = match srv {
+                Some(s) if s.ready => format!(":{} ({})", s.port, s.backend.label()),
+                Some(s) => format!(":{} loading…", s.port),
+                None => String::new(),
             };
-            let status_style = if is_serving {
-                Style::default().fg(tc.good)
-            } else {
-                style
+            let status_style = match srv {
+                Some(s) if s.ready => Style::default().fg(tc.good),
+                Some(_) => Style::default().fg(tc.warning),
+                None => style,
             };
 
             Row::new(vec![
@@ -305,7 +304,7 @@ fn draw_model_table(frame: &mut Frame, app: &mut App, area: Rect, tc: &ThemeColo
     frame.render_widget(table, area);
 }
 
-fn draw_right_panel(frame: &mut Frame, app: &App, area: Rect, tc: &ThemeColors) {
+fn draw_right_panel(frame: &mut Frame, app: &mut App, area: Rect, tc: &ThemeColors) {
     // Split vertically: server cards on top, logs on bottom
     let server_card_height = if app.servers.is_empty() {
         0
@@ -345,23 +344,37 @@ fn draw_server_cards(frame: &mut Frame, app: &App, area: Rect, tc: &ThemeColors)
         let name: String = s
             .model_name
             .chars()
-            .take(inner_width.saturating_sub(2))
+            .take(inner_width.saturating_sub(4))
             .collect();
-        lines.push(
-            Line::from(format!(" {name}"))
-                .style(Style::default().fg(tc.fg).add_modifier(Modifier::BOLD)),
-        );
-        lines.push(Line::from(vec![Span::styled(
-            format!(
-                "  {} :{} │ {}",
-                s.backend.label(),
-                s.port,
-                s.uptime_display()
+        let (state, state_color) = if s.ready {
+            ("●", tc.good)
+        } else {
+            ("◌", tc.warning)
+        };
+        lines.push(Line::from(vec![
+            Span::styled(format!(" {state} "), Style::default().fg(state_color)),
+            Span::styled(
+                name,
+                Style::default().fg(tc.fg).add_modifier(Modifier::BOLD),
             ),
-            Style::default().fg(tc.accent),
-        )]));
+        ]));
+        lines.push(Line::from(vec![
+            Span::styled(
+                format!(
+                    "   {} :{} │ {}",
+                    s.backend.label(),
+                    s.port,
+                    s.uptime_display()
+                ),
+                Style::default().fg(tc.accent),
+            ),
+            Span::styled(
+                if s.ready { "" } else { " │ loading…" },
+                Style::default().fg(tc.warning),
+            ),
+        ]));
         lines.push(Line::from(vec![Span::styled(
-            format!("  PID {} │ {}", s.pid, s.display_url()),
+            format!("   PID {} │ {}", s.pid, s.display_url()),
             Style::default().fg(tc.muted),
         )]));
     }
@@ -369,18 +382,24 @@ fn draw_server_cards(frame: &mut Frame, app: &App, area: Rect, tc: &ThemeColors)
     frame.render_widget(Paragraph::new(lines).block(block), area);
 }
 
-fn draw_log_panel(frame: &mut Frame, app: &App, area: Rect, tc: &ThemeColors) {
+fn draw_log_panel(frame: &mut Frame, app: &mut App, area: Rect, tc: &ThemeColors) {
     let focused = app.focus == Focus::Serve && app.input_mode == InputMode::Normal;
     let wrap_label = if app.log_wrap { "wrap:on" } else { "wrap:off" };
+
+    let title = if app.log_scroll > 0 {
+        format!(" Logs (scrolled ▲{}) ", app.log_scroll)
+    } else {
+        " Logs ".to_string()
+    };
 
     let block = Block::default()
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)
         .border_style(Style::default().fg(if focused { tc.accent } else { tc.border }))
-        .title(" Logs ")
+        .title(title)
         .title_style(Style::default().fg(tc.title).add_modifier(Modifier::BOLD))
         .title_bottom(
-            Line::from(format!(" [w]:{wrap_label} [C]:clear [S+←→]:resize "))
+            Line::from(format!(" j/k:scroll [w]:{wrap_label} [C]:clear "))
                 .right_aligned()
                 .style(Style::default().fg(tc.muted)),
         )
@@ -424,8 +443,10 @@ fn draw_log_panel(frame: &mut Frame, app: &App, area: Rect, tc: &ThemeColors) {
         }
     }
 
-    // Auto-scroll to bottom
-    let skip = display_lines.len().saturating_sub(visible);
+    // Pinned to the bottom unless the user scrolled up
+    let max_scroll = display_lines.len().saturating_sub(visible);
+    app.log_scroll = app.log_scroll.min(max_scroll);
+    let skip = display_lines.len().saturating_sub(visible + app.log_scroll);
 
     let lines: Vec<Line> = display_lines
         .iter()
@@ -480,7 +501,7 @@ fn draw_status_bar(frame: &mut Frame, app: &App, area: Rect, tc: &ThemeColors) {
     let help = match app.input_mode {
         InputMode::Search => "type to filter │ Enter:confirm │ Esc:clear",
         InputMode::StopPopup => "j/k:select │ Enter:stop │ Esc:cancel",
-        InputMode::ServerExit => "j/k:scroll │ Enter/Esc:dismiss",
+        InputMode::ServerExit => "j/k:scroll │ r:restart │ Enter/Esc:dismiss",
         InputMode::ConfirmServe => {
             "j/k:field │ h/l/Space:change │ e:edit │ s:save default │ Enter:serve │ Esc:cancel"
         }
@@ -563,7 +584,7 @@ fn draw_backend_popup(frame: &mut Frame, app: &App, tc: &ThemeColors) {
 }
 
 fn draw_confirm_popup(frame: &mut Frame, app: &App, tc: &ThemeColors) {
-    let area = centered_rect(62, 17, frame.area());
+    let area = centered_rect(62, 18, frame.area());
     frame.render_widget(Clear, area);
 
     let block = Block::default()
@@ -616,6 +637,7 @@ fn draw_confirm_popup(frame: &mut Frame, app: &App, tc: &ThemeColors) {
                 format!("< {backend_label} >"),
                 String::new(), // status span appended below
             ),
+            ConfirmField::Host => ("Host", preset.host.clone(), String::new()),
             ConfirmField::Port => ("Port", app.confirm_port_input.clone(), String::new()),
             ConfirmField::CtxSize => (
                 "Context",
@@ -624,7 +646,13 @@ fn draw_confirm_popup(frame: &mut Frame, app: &App, tc: &ThemeColors) {
                     if preset.use_ctx_size { "x" } else { " " },
                     preset.ctx_size
                 ),
-                "(Space toggles)".into(),
+                match app.confirm_model_ctx {
+                    Some(max) if u64::from(preset.ctx_size) > max => {
+                        format!("(exceeds model max {max}!)")
+                    }
+                    Some(max) => format!("(model max {max})"),
+                    None => "(Space toggles)".into(),
+                },
             ),
             ConfirmField::FlashAttn => (
                 "Flash attn",
@@ -860,7 +888,7 @@ fn draw_server_exit_popup(frame: &mut Frame, app: &mut App, tc: &ThemeColors) {
         .border_type(BorderType::Rounded)
         .border_style(Style::default().fg(tc.error))
         .title_bottom(
-            Line::from(" j/k:scroll │ Enter/Esc:dismiss ")
+            Line::from(" j/k:scroll │ r:restart │ Enter/Esc:dismiss ")
                 .right_aligned()
                 .style(Style::default().fg(tc.muted)),
         )
@@ -873,7 +901,7 @@ fn draw_server_exit_popup(frame: &mut Frame, app: &mut App, tc: &ThemeColors) {
         Line::from(vec![
             Span::styled("  Model:   ", Style::default().fg(tc.muted)),
             Span::styled(
-                info.model_name.clone(),
+                info.model.name.clone(),
                 Style::default().fg(tc.fg).add_modifier(Modifier::BOLD),
             ),
         ]),


### PR DESCRIPTION
## What

The batch of improvements identified while reviewing the codebase after #39.

### Responsiveness
- **Parallel backend detection & model fetches** — the 9 backend detectors (7 of which make HTTP probes with 800ms timeouts) and the 4 API model fetches now run on scoped threads. Startup and `r`-refresh cost one probe's latency instead of the sum; first frame renders in ~45ms locally.

### Robustness
- **Reader threads instead of `fcntl(O_NONBLOCK)`** — each child's stdout/stderr is read on a dedicated thread feeding an mpsc channel. Removes the `unsafe` block, makes serving work on Windows (where the old code would block the UI forever), preserves the `\r` progress-line collapsing, and raises the log ring buffer from 200 to 1000 lines. Reader threads are joined on exit/stop so the crash popup always includes the final output.
- **Graceful stop** — SIGTERM with a 2s grace period before SIGKILL (unix).
- **Panic hook** — restores the terminal (raw mode + alternate screen) before printing the panic, so a bug can't leave the shell unusable.
- **External port conflict detection** — `do_serve` now bind-tests the port, so a port held by another process (e.g. Ollama) produces a status message instead of an instant crash popup.

### UX
- **Readiness states** — servers probe `/health` once per second until ready: llama-server answers 503 while loading (verified: `000 → 503 → 200`), other backends' 404 counts as up. Server cards show `◌ … loading…` → `● ready`; the table status column matches.
- **Restart from crash popup** — `r` relaunches the exited server with identical model/backend/settings (the launch preset now travels with the server handle).
- **Host field** in the serve modal (switch `0.0.0.0` ↔ `127.0.0.1`), persisted by save-defaults.
- **Log scrollback** — `j/k`, `Ctrl-u/d`, `g/G` scroll the logs panel when focused; title shows `(scrolled ▲N)`.
- **Mouse capture dropped** — it was enabled but unhandled, and it blocked normal terminal text selection/copy.

### Polish
- **GGUF header parsing** — reads `general.size_label`, `general.architecture`, and `<arch>.context_length` from the file header (seeking past arrays, so it's a few KB read regardless of model size). Fills the Params column for files with uninformative names (e.g. `gemma-3.Q8_0` → `2.5B`) and the serve modal warns when ctx-size exceeds the model's trained context.
- **`--version` / `--help`** CLI flags.
- **Deduplicated** the three identical OpenAI-style model fetchers in backends.rs.

## Testing

- 51 tests pass (3 new GGUF parser tests incl. truncated/corrupt headers), clippy warnings *down* from 39 to 27 (no new ones), `cargo fmt` applied.
- Exercised end-to-end in tmux against real llama-server + model: startup timing, params column, host/context fields, serve → ready transition, external `kill -9` → crash popup → `r` restart, log scrolling, external port conflict, and clean process teardown on quit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)